### PR TITLE
Add comprehensive touch support for iPad/iPhone browser use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,9 +1029,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1049,9 +1046,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1069,9 +1063,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1089,9 +1080,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1109,9 +1097,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1129,9 +1114,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1149,9 +1131,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1169,9 +1148,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1189,9 +1165,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1215,9 +1188,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1241,9 +1211,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1267,9 +1234,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1293,9 +1257,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1319,9 +1280,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1345,9 +1303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1371,9 +1326,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/src/components/panels/ContextMenu.tsx
+++ b/src/components/panels/ContextMenu.tsx
@@ -10,15 +10,20 @@ interface ContextMenuProps {
 export function ContextMenu({ x, y, onGroupNodes, onClose }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
 
-  // Dismiss on click outside
+  // Dismiss on click or tap outside
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+    const handler = (e: MouseEvent | TouchEvent) => {
+      const target = e instanceof TouchEvent ? e.touches[0]?.target : e.target
+      if (menuRef.current && target && !menuRef.current.contains(target as Node)) {
         onClose()
       }
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
+    document.addEventListener('mousedown', handler as EventListener)
+    document.addEventListener('touchstart', handler as EventListener)
+    return () => {
+      document.removeEventListener('mousedown', handler as EventListener)
+      document.removeEventListener('touchstart', handler as EventListener)
+    }
   }, [onClose])
 
   // Dismiss on Escape

--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -133,10 +133,12 @@ export function EditorPanel() {
 
   const onContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
+    // If already shown via long-press (iPadOS 16+ fires contextmenu after long-press too)
+    if (contextMenu) return;
     const selected = useEditorStore.getState().nodes.filter((n) => n.selected);
     if (selected.length < 2) return;
     setContextMenu({ x: e.clientX, y: e.clientY });
-  }, []);
+  }, [contextMenu]);
 
   // Long-press on the canvas shows the context menu on touch devices
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useMemo } from "react";
+import { useCallback, useRef, useState, useMemo, useEffect } from "react";
 import {
   ReactFlow,
   Background,
@@ -138,9 +138,36 @@ export function EditorPanel() {
     setContextMenu({ x: e.clientX, y: e.clientY });
   }, []);
 
+  // Long-press on the canvas shows the context menu on touch devices
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const onCanvasTouchStart = useCallback((e: React.TouchEvent) => {
+    const selected = useEditorStore.getState().nodes.filter((n) => n.selected);
+    if (selected.length < 2) return;
+    const touch = e.touches[0];
+    longPressTimer.current = setTimeout(() => {
+      setContextMenu({ x: touch.clientX, y: touch.clientY });
+    }, 500);
+  }, []);
+
+  const cancelLongPress = useCallback(() => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }, []);
+
+  // Clean up timer on unmount
+  useEffect(() => cancelLongPress, [cancelLongPress]);
+
   return (
     <HaltDimmedContext.Provider value={dimmedNodeIds}>
-      <div className="flex-1 relative bg-gray-950">
+      <div
+        className="flex-1 relative bg-gray-950"
+        onTouchStart={onCanvasTouchStart}
+        onTouchMove={cancelLongPress}
+        onTouchEnd={cancelLongPress}
+      >
         <SearchBar
           nodes={nodes}
           updateNodeData={

--- a/src/components/sketch/SketchNodePalette.tsx
+++ b/src/components/sketch/SketchNodePalette.tsx
@@ -68,7 +68,7 @@ export function SketchNodePalette() {
                   onMouseEnter={(e) => handleMouseEnter(e, item)}
                   onMouseLeave={handleMouseLeave}
                   onTouchStart={(e) =>
-                    handleTouchStart(e, item.type, item.defaultData as Record<string, unknown>, item.label)
+                    handleTouchStart(e, item.type, item.defaultData as unknown as Record<string, unknown>, item.label)
                   }
                   className={`
                     cursor-grab active:cursor-grabbing

--- a/src/components/sketch/SketchNodePalette.tsx
+++ b/src/components/sketch/SketchNodePalette.tsx
@@ -8,6 +8,7 @@ import {
   type SketchPaletteItem,
 } from '@/types/sketchNodes'
 import { NodeTooltipPopover } from '@/components/toolbar/NodeTooltipPopover'
+import { useTouchNodeDrop } from '@/hooks/useTouchNodeDrop'
 
 const SKETCH_CATEGORY_ORDER: SketchNodeCategory[] = [
   'sketch_primitive',
@@ -20,6 +21,7 @@ const SKETCH_CATEGORY_ORDER: SketchNodeCategory[] = [
 export function SketchNodePalette() {
   const [tooltip, setTooltip] = useState<{ item: SketchPaletteItem; rect: DOMRect } | null>(null)
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { handleTouchStart } = useTouchNodeDrop()
 
   const handleMouseEnter = useCallback((e: React.MouseEvent, item: SketchPaletteItem) => {
     const rect = e.currentTarget.getBoundingClientRect()
@@ -65,6 +67,9 @@ export function SketchNodePalette() {
                   onDragStart={(e) => onDragStart(e, item.type)}
                   onMouseEnter={(e) => handleMouseEnter(e, item)}
                   onMouseLeave={handleMouseLeave}
+                  onTouchStart={(e) =>
+                    handleTouchStart(e, item.type, item.defaultData as Record<string, unknown>, item.label)
+                  }
                   className={`
                     cursor-grab active:cursor-grabbing
                     ${SKETCH_CATEGORY_COLORS[item.category]} ${SKETCH_CATEGORY_TEXT[item.category]}

--- a/src/components/sketch/SketchPreviewPanel.tsx
+++ b/src/components/sketch/SketchPreviewPanel.tsx
@@ -18,6 +18,8 @@ function SvgViewer({ svg }: { svg: string }) {
   const [translate, setTranslate] = useState({ x: 0, y: 0 })
   const [isPanning, setIsPanning] = useState(false)
   const panStart = useRef({ x: 0, y: 0, tx: 0, ty: 0 })
+  // Touch state for pinch-zoom
+  const pinchRef = useRef<{ dist: number; midX: number; midY: number; tx: number; ty: number; sc: number } | null>(null)
 
   // Wheel zoom (zoom toward cursor)
   const onWheel = useCallback((e: React.WheelEvent) => {
@@ -58,6 +60,66 @@ function SvgViewer({ svg }: { svg: string }) {
 
   const onMouseUp = useCallback(() => {
     setIsPanning(false)
+  }, [])
+
+  // ── Touch handlers ──────────────────────────────────────────────────────────
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    e.preventDefault()
+    if (e.touches.length === 1) {
+      const t = e.touches[0]
+      setIsPanning(true)
+      setTranslate((prev) => {
+        panStart.current = { x: t.clientX, y: t.clientY, tx: prev.x, ty: prev.y }
+        return prev
+      })
+      pinchRef.current = null
+    } else if (e.touches.length === 2) {
+      setIsPanning(false)
+      const [a, b] = [e.touches[0], e.touches[1]]
+      const dist = Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY)
+      const midX = (a.clientX + b.clientX) / 2
+      const midY = (a.clientY + b.clientY) / 2
+      const container = containerRef.current
+      if (container) {
+        const rect = container.getBoundingClientRect()
+        setTranslate((prev) => {
+          setScale((sc) => {
+            pinchRef.current = { dist, midX: midX - rect.left, midY: midY - rect.top, tx: prev.x, ty: prev.y, sc }
+            return sc
+          })
+          return prev
+        })
+      }
+    }
+  }, [])
+
+  const onTouchMove = useCallback((e: React.TouchEvent) => {
+    e.preventDefault()
+    if (e.touches.length === 1 && pinchRef.current === null) {
+      if (!isPanning) return
+      const t = e.touches[0]
+      setTranslate({
+        x: panStart.current.tx + (t.clientX - panStart.current.x),
+        y: panStart.current.ty + (t.clientY - panStart.current.y),
+      })
+    } else if (e.touches.length === 2 && pinchRef.current !== null) {
+      const [a, b] = [e.touches[0], e.touches[1]]
+      const newDist = Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY)
+      const { dist: startDist, midX, midY, tx, ty, sc: startScale } = pinchRef.current
+      const newScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, startScale * (newDist / startDist)))
+      const ratio = newScale / startScale
+      setScale(newScale)
+      setTranslate({
+        x: midX - ratio * (midX - tx),
+        y: midY - ratio * (midY - ty),
+      })
+    }
+  }, [isPanning])
+
+  const onTouchEnd = useCallback(() => {
+    setIsPanning(false)
+    pinchRef.current = null
   }, [])
 
   // Fit to view
@@ -115,6 +177,7 @@ function SvgViewer({ svg }: { svg: string }) {
         className="w-full h-full"
         style={{
           cursor: isPanning ? 'grabbing' : 'grab',
+          touchAction: 'none',
           backgroundImage: [
             'linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px)',
             'linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)',
@@ -127,6 +190,9 @@ function SvgViewer({ svg }: { svg: string }) {
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUp}
         onMouseLeave={onMouseUp}
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
       >
         <div
           ref={contentRef}
@@ -144,21 +210,21 @@ function SvgViewer({ svg }: { svg: string }) {
       <div className="absolute bottom-3 right-3 flex flex-col gap-1 z-10">
         <button
           onClick={() => setScale((s) => Math.min(MAX_ZOOM, s + ZOOM_STEP * s))}
-          className="w-7 h-7 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 text-sm flex items-center justify-center"
+          className="w-10 h-10 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 text-sm flex items-center justify-center"
           title="Zoom in"
         >
           +
         </button>
         <button
           onClick={() => setScale((s) => Math.max(MIN_ZOOM, s - ZOOM_STEP * s))}
-          className="w-7 h-7 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 text-sm flex items-center justify-center"
+          className="w-10 h-10 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 text-sm flex items-center justify-center"
           title="Zoom out"
         >
           -
         </button>
         <button
           onClick={fitToView}
-          className="w-7 h-7 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 flex items-center justify-center"
+          className="w-10 h-10 bg-gray-800/90 border border-gray-700 rounded text-gray-300 hover:bg-gray-700 flex items-center justify-center"
           title="Fit to view"
         >
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -167,7 +233,7 @@ function SvgViewer({ svg }: { svg: string }) {
         </button>
         <button
           onClick={resetZoom}
-          className="w-7 h-7 bg-gray-800/90 border border-gray-700 rounded text-gray-400 hover:bg-gray-700 text-[9px] font-bold flex items-center justify-center"
+          className="w-10 h-10 bg-gray-800/90 border border-gray-700 rounded text-gray-400 hover:bg-gray-700 text-[9px] font-bold flex items-center justify-center"
           title="Reset to 1:1"
         >
           1:1

--- a/src/components/toolbar/ExportDropdown.tsx
+++ b/src/components/toolbar/ExportDropdown.tsx
@@ -106,16 +106,21 @@ export function ExportDropdown() {
   const tabs = useEditorStore((s) => s.tabs)
   const activeTabId = useEditorStore((s) => s.activeTabId)
 
-  // Close dropdown on outside click
+  // Close dropdown on outside click or tap
   useEffect(() => {
     if (!open) return
-    const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+    const handler = (e: MouseEvent | TouchEvent) => {
+      const target = e instanceof TouchEvent ? e.touches[0]?.target : e.target
+      if (dropdownRef.current && target && !dropdownRef.current.contains(target as Node)) {
         setOpen(false)
       }
     }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
+    document.addEventListener('mousedown', handler as EventListener)
+    document.addEventListener('touchstart', handler as EventListener)
+    return () => {
+      document.removeEventListener('mousedown', handler as EventListener)
+      document.removeEventListener('touchstart', handler as EventListener)
+    }
   }, [open])
 
   const openSketchModal = (format: SketchFormat) => {

--- a/src/components/toolbar/NodePalette.tsx
+++ b/src/components/toolbar/NodePalette.tsx
@@ -3,6 +3,7 @@ import { PALETTE_ITEMS, CATEGORY_COLORS, CATEGORY_TEXT, CATEGORY_LABELS, type Pa
 import { PACK_PALETTE_ITEMS, PACK_CATEGORY_ORDER, PACK_CATEGORY_COLORS, PACK_CATEGORY_TEXT, PACK_CATEGORY_LABELS } from '@/nodepacks'
 import { useEditorStore } from '@/store/editorStore'
 import { NodeTooltipPopover } from './NodeTooltipPopover'
+import { useTouchNodeDrop } from '@/hooks/useTouchNodeDrop'
 
 const CORE_CATEGORY_ORDER: string[] = [
   'primitive3d',
@@ -38,6 +39,7 @@ export function NodePalette() {
 
   const [tooltip, setTooltip] = useState<{ item: PaletteItem; rect: DOMRect } | null>(null)
   const tooltipTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { handleTouchStart } = useTouchNodeDrop()
 
   const handleMouseEnter = useCallback((e: React.MouseEvent, item: PaletteItem) => {
     const rect = e.currentTarget.getBoundingClientRect()
@@ -85,6 +87,9 @@ export function NodePalette() {
                   onDragStart={(e) => onDragStart(e, item.type)}
                   onMouseEnter={(e) => handleMouseEnter(e, item)}
                   onMouseLeave={handleMouseLeave}
+                  onTouchStart={(e) =>
+                    handleTouchStart(e, item.type, item.defaultData as Record<string, unknown>, item.label)
+                  }
                   className={`
                     cursor-grab active:cursor-grabbing
                     ${ALL_CATEGORY_COLORS[item.category]} ${ALL_CATEGORY_TEXT[item.category]}

--- a/src/hooks/useTouchNodeDrop.ts
+++ b/src/hooks/useTouchNodeDrop.ts
@@ -1,0 +1,141 @@
+import { useCallback, useRef } from 'react'
+import { useReactFlow, type Node } from '@xyflow/react'
+import { useEditorStore } from '@/store/editorStore'
+
+interface TouchDragState {
+  nodeType: string
+  defaultData: Record<string, unknown>
+  label: string
+  ghost: HTMLDivElement | null
+  touchId: number
+}
+
+/**
+ * Provides touch drag-and-drop for node palette chips.
+ * HTML5 drag-and-drop is unsupported on iOS/iPadOS, so this hook
+ * simulates the same interaction using touch events:
+ *   touchstart → create ghost  →  touchmove → follow finger
+ *   touchend → drop on canvas → addNode at flow position
+ */
+export function useTouchNodeDrop() {
+  const { screenToFlowPosition } = useReactFlow()
+  const addNode = useEditorStore((s) => s.addNode)
+  const dragState = useRef<TouchDragState | null>(null)
+
+  const cleanup = useCallback(() => {
+    const state = dragState.current
+    if (!state) return
+    if (state.ghost && state.ghost.parentNode) {
+      state.ghost.parentNode.removeChild(state.ghost)
+    }
+    dragState.current = null
+  }, [])
+
+  const handleTouchMove = useCallback((e: TouchEvent) => {
+    const state = dragState.current
+    if (!state || !state.ghost) return
+    const touch = Array.from(e.changedTouches).find((t) => t.identifier === state.touchId)
+    if (!touch) return
+
+    // Prevent page scroll/zoom during the drag
+    e.preventDefault()
+
+    state.ghost.style.left = `${touch.clientX - 30}px`
+    state.ghost.style.top = `${touch.clientY - 16}px`
+  }, [])
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      const state = dragState.current
+      if (!state) return
+
+      const touch = Array.from(e.changedTouches).find((t) => t.identifier === state.touchId)
+
+      // Remove ghost before hit-testing so it doesn't intercept elementFromPoint
+      cleanup()
+
+      document.removeEventListener('touchmove', handleTouchMove)
+      document.removeEventListener('touchend', handleTouchEnd)
+
+      if (!touch) return
+
+      // Check whether the finger lifted inside the ReactFlow canvas
+      const canvasEl = document.querySelector('.react-flow__renderer')
+      if (!canvasEl) return
+
+      const rect = canvasEl.getBoundingClientRect()
+      const { clientX, clientY } = touch
+      if (
+        clientX < rect.left ||
+        clientX > rect.right ||
+        clientY < rect.top ||
+        clientY > rect.bottom
+      ) {
+        return
+      }
+
+      const position = screenToFlowPosition({ x: clientX, y: clientY })
+
+      const newNode: Node = {
+        id: `${state.nodeType}-touch-${Date.now()}`,
+        type: state.nodeType,
+        position,
+        data: { ...state.defaultData },
+      }
+
+      addNode(newNode)
+    },
+    [cleanup, handleTouchMove, screenToFlowPosition, addNode],
+  )
+
+  const handleTouchStart = useCallback(
+    (
+      e: React.TouchEvent,
+      nodeType: string,
+      defaultData: Record<string, unknown>,
+      label: string,
+    ) => {
+      // Only act on the first touch point
+      const touch = e.touches[0]
+      if (!touch) return
+
+      // Build ghost element — identical chip style to palette items
+      const ghost = document.createElement('div')
+      ghost.textContent = label
+      Object.assign(ghost.style, {
+        position: 'fixed',
+        pointerEvents: 'none',
+        zIndex: '9999',
+        left: `${touch.clientX - 30}px`,
+        top: `${touch.clientY - 16}px`,
+        padding: '2px 8px',
+        borderRadius: '4px',
+        fontSize: '10px',
+        fontWeight: '500',
+        background: 'rgba(55,65,81,0.95)',
+        color: '#e5e7eb',
+        border: '1px solid rgba(255,255,255,0.15)',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+        userSelect: 'none',
+        whiteSpace: 'nowrap',
+        opacity: '0.92',
+      })
+      document.body.appendChild(ghost)
+
+      dragState.current = {
+        nodeType,
+        defaultData,
+        label,
+        ghost,
+        touchId: touch.identifier,
+      }
+
+      // Passive:false so touchmove can call preventDefault and block scroll
+      document.addEventListener('touchmove', handleTouchMove, { passive: false })
+      document.addEventListener('touchend', handleTouchEnd)
+    },
+    [handleTouchMove, handleTouchEnd],
+  )
+
+  return { handleTouchStart }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,21 @@
   letter-spacing: 0.1em;
 }
 
+/* ─── Touch ergonomics ────────────────────────────────────────────────────── */
+
+/* Remove the blue/grey tap highlight on iOS/Android */
+* {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Widen the panel separators slightly so they are easy to grab on touch */
+[data-separator].separator-h {
+  width: 10px;
+}
+[data-separator].separator-v {
+  height: 10px;
+}
+
 /* ─── Sketch SVG preview ──────────────────────────────────────────────────── */
 .sketch-svg-container svg {
   max-width: 100%;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "baseUrl": ".",
+    "ignoreDeprecations": "5.0",
     "paths": {
       "@/*": ["src/*"]
     }


### PR DESCRIPTION
- New useTouchNodeDrop hook: ghost-element touch drag from palette chips
  to the ReactFlow canvas (HTML5 drag-and-drop is unsupported on iOS)
- NodePalette + SketchNodePalette: wire onTouchStart via the hook
- SketchPreviewPanel SvgViewer: single-finger pan and two-finger
  pinch-zoom via touch events; touch-action:none on container;
  zoom buttons enlarged to 40px (44px minimum touch target)
- ContextMenu + ExportDropdown: add touchstart alongside mousedown
  for outside-tap dismissal
- EditorPanel: long-press (500ms) on canvas triggers context menu
  when 2+ nodes are selected (belt-and-suspenders for iOS contextmenu)
- index.css: -webkit-tap-highlight-color removed; panel separators
  widened to 10px for easier touch grabbing

https://claude.ai/code/session_015p3ggbmBtcJ2ToD6xifwxs