### PR TITLE
Implement F-002: Scoped Sub-Editor Preview

### DIFF
--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1115,3 +1115,262 @@ export function generateLoopBodyCode(
 
   return `${signature} {\n${indented}}\n`;
 }
+
+// ─── F-002: Upstream geometry emitter ────────────────────────────────────────
+
+/**
+ * Emits OpenSCAD code for geometry flowing into a specific input handle of a
+ * node in a given tab's graph. Used by loop/module preview to synthesize the
+ * upstream geometry that the body module receives via children().
+ */
+export function emitUpstreamGeometry(
+  tabNodes: Node[],
+  tabEdges: Edge[],
+  targetNodeId: string,
+  targetHandleIndex: number,
+  globalParameters?: GlobalParameter[],
+  tabs?: EditorTab[],
+  importedFiles?: Record<string, string>,
+): string {
+  const codeNodes = tabNodes.filter((n) => n.type !== "group_node");
+  const nodesMap = new Map(codeNodes.map((n) => [n.id, n]));
+  const childrenOf = buildAdjacency(tabEdges);
+
+  const childRefs = childrenOf.get(targetNodeId) ?? [];
+  const ref = childRefs.find((c) => c.handleIndex === targetHandleIndex);
+  if (!ref) return "";
+
+  return emitNode(
+    ref.nodeId,
+    nodesMap,
+    childrenOf,
+    new Set(),
+    new Set(),
+    0,
+    tabs,
+    globalParameters,
+    importedFiles,
+  );
+}
+
+// ─── F-002: Loop preview code generation ─────────────────────────────────────
+
+/**
+ * Synthesizes a complete renderable OpenSCAD program for previewing a loop
+ * body tab. Produces: global params + body module definition + optional
+ * upstream geometry + invocation at the requested iteration or range.
+ */
+export function generateLoopPreviewCode(opts: {
+  bodyTabModuleName: string;
+  bodyTabNodes: Node[];
+  bodyTabEdges: Edge[];
+  parentTab?: EditorTab;
+  parentNodeId?: string;
+  hasGeometryInput: boolean;
+  previewMode: "single" | "range";
+  previewValue: number;
+  previewRange: { start: number; end: number; step: number } | null;
+  globalParameters?: GlobalParameter[];
+  tabs?: EditorTab[];
+  importedFiles?: Record<string, string>;
+}): string {
+  const {
+    bodyTabModuleName,
+    bodyTabNodes,
+    bodyTabEdges,
+    parentTab,
+    parentNodeId,
+    hasGeometryInput,
+    previewMode,
+    previewValue,
+    previewRange,
+    globalParameters,
+    tabs,
+    importedFiles,
+  } = opts;
+
+  let code = "";
+
+  if (globalParameters && globalParameters.length > 0) {
+    for (const p of globalParameters) {
+      code += emitGlobalParameter(p);
+    }
+    code += "\n";
+  }
+
+  if (tabs) {
+    for (const tab of tabs) {
+      if (tab.moduleName === bodyTabModuleName) continue;
+      if (tab.tabType === "module") {
+        const mc = generateModuleCode(tab.moduleName, tab.nodes, tab.edges);
+        if (mc.trim()) code += mc + "\n";
+      } else if (tab.tabType === "loop") {
+        const lc = generateLoopBodyCode(tab.moduleName, tab.nodes, tab.edges);
+        if (lc.trim()) code += lc + "\n";
+      }
+    }
+  }
+
+  const bodyDef = generateLoopBodyCode(bodyTabModuleName, bodyTabNodes, bodyTabEdges);
+  code += bodyDef + "\n";
+
+  const ctxNode = bodyTabNodes.find((n) => n.type === "loop_context");
+  const varName = ctxNode
+    ? sanitizeIdentifier(
+        String((ctxNode.data as Record<string, unknown>).varName || "i"),
+        "i",
+      )
+    : "i";
+  const safeModuleName = sanitizeIdentifier(bodyTabModuleName, "for_body");
+
+  const rangeStart = previewRange?.start ?? 0;
+  const rangeEnd = previewRange?.end ?? 5;
+  const rangeStep = previewRange?.step ?? 1;
+
+  let upstreamCode = "";
+  if (hasGeometryInput && parentTab && parentNodeId) {
+    upstreamCode = emitUpstreamGeometry(
+      parentTab.nodes,
+      parentTab.edges,
+      parentNodeId,
+      0,
+      globalParameters,
+      tabs,
+      importedFiles,
+    );
+  }
+
+  const hasUpstream = upstreamCode.trim().length > 0;
+
+  if (previewMode === "single") {
+    const iterVal = previewValue;
+    if (hasUpstream) {
+      const indentedUpstream = upstreamCode
+        .split("\n")
+        .map((l) => (l.trim() ? "  " + l : l))
+        .join("\n");
+      code += `${safeModuleName}(${iterVal}, ${rangeStart}, ${rangeEnd}, ${rangeStep}) {\n${indentedUpstream}}\n`;
+    } else {
+      code += `${safeModuleName}(${iterVal}, ${rangeStart}, ${rangeEnd}, ${rangeStep});\n`;
+    }
+  } else {
+    if (hasUpstream) {
+      const indentedUpstream = upstreamCode
+        .split("\n")
+        .map((l) => (l.trim() ? "    " + l : l))
+        .join("\n");
+      code +=
+        `for (${varName} = [${rangeStart} : ${rangeStep} : ${rangeEnd}])\n` +
+        `  ${safeModuleName}(${varName}, ${rangeStart}, ${rangeEnd}, ${rangeStep}) {\n` +
+        `${indentedUpstream}  }\n`;
+    } else {
+      code +=
+        `for (${varName} = [${rangeStart} : ${rangeStep} : ${rangeEnd}])\n` +
+        `  ${safeModuleName}(${varName}, ${rangeStart}, ${rangeEnd}, ${rangeStep});\n`;
+    }
+  }
+
+  return code;
+}
+
+// ─── F-002: Module preview code generation ───────────────────────────────────
+
+/**
+ * Synthesizes a complete renderable OpenSCAD program for previewing a module
+ * tab. Produces: global params + module definition + a call with user-provided
+ * argument overrides (falling back to module_arg defaults).
+ */
+export function generateModulePreviewCode(opts: {
+  moduleName: string;
+  moduleTabNodes: Node[];
+  moduleTabEdges: Edge[];
+  argOverrides: Record<string, string>;
+  globalParameters?: GlobalParameter[];
+  tabs?: EditorTab[];
+}): string {
+  const {
+    moduleName,
+    moduleTabNodes,
+    moduleTabEdges,
+    argOverrides,
+    globalParameters,
+    tabs,
+  } = opts;
+
+  let code = "";
+
+  if (globalParameters && globalParameters.length > 0) {
+    for (const p of globalParameters) {
+      code += emitGlobalParameter(p);
+    }
+    code += "\n";
+  }
+
+  if (tabs) {
+    for (const tab of tabs) {
+      if (tab.moduleName === moduleName) continue;
+      if (tab.tabType === "module") {
+        const mc = generateModuleCode(tab.moduleName, tab.nodes, tab.edges);
+        if (mc.trim()) code += mc + "\n";
+      } else if (tab.tabType === "loop") {
+        const lc = generateLoopBodyCode(tab.moduleName, tab.nodes, tab.edges);
+        if (lc.trim()) code += lc + "\n";
+      }
+    }
+  }
+
+  const moduleDef = generateModuleCode(moduleName, moduleTabNodes, moduleTabEdges);
+  code += moduleDef + "\n";
+
+  const safeModuleName = sanitizeIdentifier(moduleName, "module");
+  const argNodes = moduleTabNodes.filter((n) => n.type === "module_arg");
+  const argParts: string[] = [];
+
+  for (const n of argNodes) {
+    const d = n.data as Record<string, unknown>;
+    const rawName = String(d.argName || "");
+    if (!rawName) continue;
+    const name = sanitizeIdentifier(rawName, "arg");
+    const dataType = String(d.dataType || "number");
+    const overrideVal = argOverrides[rawName];
+    const defaultVal = String(d.defaultValue ?? "0");
+    const rawValue = overrideVal !== undefined ? overrideVal : defaultVal;
+
+    let formattedValue = rawValue;
+    if (dataType === "string") {
+      const isQuoted = /^\s*"[\s\S]*"\s*$/.test(rawValue);
+      formattedValue = isQuoted
+        ? rawValue
+        : `"${rawValue.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    } else if (dataType === "boolean") {
+      formattedValue = rawValue === "true" ? "true" : "false";
+    }
+
+    argParts.push(`${name} = ${formattedValue}`);
+  }
+
+  code += `${safeModuleName}(${argParts.join(", ")});\n`;
+  return code;
+}
+
+// ─── F-002: Empty geometry detection ─────────────────────────────────────────
+
+/**
+ * Returns true if the generated OpenSCAD code contains renderable geometry.
+ * Filters out echo(), comments, variable declarations, and module definitions.
+ */
+export function hasRenderableGeometry(code: string): boolean {
+  const stripped = code.replace(/\/\*[\s\S]*?\*\//g, "");
+  const lines = stripped.split("\n");
+
+  const nonGeometryPattern =
+    /^\s*($|\/\/|module\s|echo\s*\(|[a-zA-Z_][a-zA-Z0-9_]*\s*=|for\s*\(|\}|\{)/;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (nonGeometryPattern.test(trimmed)) continue;
+    return true;
+  }
+  return false;
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1355,22 +1355,146 @@ export function generateModulePreviewCode(opts: {
 
 // ─── F-002: Empty geometry detection ─────────────────────────────────────────
 
+// Known OpenSCAD primitive geometry functions
+const OPENSCAD_PRIMITIVES = new Set([
+  "sphere", "cube", "cylinder", "polyhedron",
+  "circle", "square", "polygon", "text",
+  "import", "surface",
+  "linear_extrude", "rotate_extrude",
+  "hull", "minkowski", "union", "difference", "intersection",
+  "color", "translate", "rotate", "scale", "mirror", "multmatrix",
+  "offset", "projection", "render",
+]);
+
+// Non-geometry keywords / call names that should not count as renderable
+const IGNORED_CALL_NAMES = new Set([
+  "module", "function", "echo", "for", "if", "else",
+  "each", "let", "assert", "use", "include",
+]);
+
+function _stripBlockComments(code: string): string {
+  return code.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function _stripLineComment(line: string): string {
+  // Avoid stripping // inside strings — good enough approximation for OpenSCAD
+  const idx = line.indexOf("//");
+  return idx >= 0 ? line.slice(0, idx) : line;
+}
+
 /**
- * Returns true if the generated OpenSCAD code contains renderable geometry.
- * Filters out echo(), comments, variable declarations, and module definitions.
+ * Parses `code` into:
+ * - `moduleBodies`: map of module name → the source text of that module's body
+ * - `topLevel`: top-level code (everything outside module definitions)
  */
-export function hasRenderableGeometry(code: string): boolean {
-  const stripped = code.replace(/\/\*[\s\S]*?\*\//g, "");
-  const lines = stripped.split("\n");
+function _extractModules(code: string): {
+  moduleBodies: Map<string, string>;
+  topLevel: string;
+} {
+  const moduleBodies = new Map<string, string>();
+  const topLevelLines: string[] = [];
+  const lines = code.split("\n");
 
-  const nonGeometryPattern =
-    /^\s*($|\/\/|module\s|echo\s*\(|[a-zA-Z_][a-zA-Z0-9_]*\s*=|for\s*\(|\}|\{)/;
+  let i = 0;
+  while (i < lines.length) {
+    const stripped = _stripLineComment(lines[i]).trim();
+    const moduleMatch = stripped.match(/^module\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/);
 
+    if (!moduleMatch) {
+      topLevelLines.push(lines[i]);
+      i++;
+      continue;
+    }
+
+    // Collect module body by tracking brace depth
+    const moduleName = moduleMatch[1];
+    const bodyLines: string[] = [lines[i]];
+    let depth = (lines[i].match(/\{/g) ?? []).length - (lines[i].match(/\}/g) ?? []).length;
+    i++;
+
+    // Advance until opening brace if not on same line
+    while (depth <= 0 && i < lines.length) {
+      bodyLines.push(lines[i]);
+      depth += (lines[i].match(/\{/g) ?? []).length - (lines[i].match(/\}/g) ?? []).length;
+      i++;
+    }
+
+    // Advance until closing brace
+    while (depth > 0 && i < lines.length) {
+      bodyLines.push(lines[i]);
+      depth += (lines[i].match(/\{/g) ?? []).length - (lines[i].match(/\}/g) ?? []).length;
+      i++;
+    }
+
+    moduleBodies.set(moduleName, bodyLines.join("\n"));
+  }
+
+  return { moduleBodies, topLevel: topLevelLines.join("\n") };
+}
+
+function _lineHasPrimitive(line: string): boolean {
+  return /\b(sphere|cube|cylinder|polyhedron|circle|square|polygon|text|import|surface|linear_extrude|rotate_extrude)\s*\(/.test(line);
+}
+
+function _moduleHasGeometry(
+  name: string,
+  moduleBodies: Map<string, string>,
+  visiting: Set<string>,
+  cache: Map<string, boolean>,
+): boolean {
+  if (cache.has(name)) return cache.get(name)!;
+  if (visiting.has(name)) return false; // cycle guard
+
+  const body = moduleBodies.get(name);
+  if (!body) {
+    // Unknown module — conservatively assume it might render something
+    const result = !IGNORED_CALL_NAMES.has(name);
+    cache.set(name, result);
+    return result;
+  }
+
+  visiting.add(name);
+  const result = _codeHasGeometry(body, moduleBodies, visiting, cache);
+  visiting.delete(name);
+  cache.set(name, result);
+  return result;
+}
+
+function _codeHasGeometry(
+  code: string,
+  moduleBodies: Map<string, string>,
+  visiting: Set<string>,
+  cache: Map<string, boolean>,
+): boolean {
+  const lines = code.split("\n");
   for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (nonGeometryPattern.test(trimmed)) continue;
-    return true;
+    const trimmed = _stripLineComment(line).trim();
+    if (!trimmed || trimmed === "{" || trimmed === "}") continue;
+    // Skip pure variable assignments
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*\s*=/.test(trimmed)) continue;
+    // Direct primitive call
+    if (_lineHasPrimitive(trimmed)) return true;
+    // Any other call — resolve through module map
+    const callMatches = trimmed.matchAll(/\b([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/g);
+    for (const [, callName] of callMatches) {
+      if (IGNORED_CALL_NAMES.has(callName)) continue;
+      if (OPENSCAD_PRIMITIVES.has(callName)) return true;
+      if (_moduleHasGeometry(callName, moduleBodies, visiting, cache)) return true;
+    }
   }
   return false;
+}
+
+/**
+ * Returns true if the generated OpenSCAD code contains renderable geometry.
+ *
+ * Module-aware: resolves user-defined module calls so that a call to an empty
+ * module does NOT incorrectly classify the code as geometry-bearing.
+ * Ignores: comments, variable assignments, echo(), and module definitions that
+ * contain no primitives or CSG operations.
+ */
+export function hasRenderableGeometry(code: string): boolean {
+  const stripped = _stripBlockComments(code);
+  const { moduleBodies, topLevel } = _extractModules(stripped);
+  return _codeHasGeometry(topLevel, moduleBodies, new Set(), new Map());
 }

--- a/src/components/panels/LoopPreviewControls.tsx
+++ b/src/components/panels/LoopPreviewControls.tsx
@@ -1,0 +1,125 @@
+/**
+ * F-002 R4: Iteration Slider UI
+ *
+ * Horizontal control bar rendered in the PreviewPanel header when the active
+ * tab is a loop body. Lets the user choose a single iteration value or a range
+ * to render, with a mode toggle and a bounded slider.
+ */
+import { useEditorStore } from '@/store/editorStore'
+
+export function LoopPreviewControls() {
+  const loopPreviewMode  = useEditorStore((s) => s.loopPreviewMode)
+  const loopPreviewValue = useEditorStore((s) => s.loopPreviewValue)
+  const loopPreviewRange = useEditorStore((s) => s.loopPreviewRange)
+  const setLoopPreviewMode  = useEditorStore((s) => s.setLoopPreviewMode)
+  const setLoopPreviewValue = useEditorStore((s) => s.setLoopPreviewValue)
+  const setLoopPreviewRange = useEditorStore((s) => s.setLoopPreviewRange)
+
+  const rangeStart = loopPreviewRange?.start ?? 0
+  const rangeEnd   = loopPreviewRange?.end   ?? 5
+  const rangeStep  = loopPreviewRange?.step  ?? 1
+
+  return (
+    <div className="px-3 py-1.5 border-b border-white/10 bg-amber-950/20 flex flex-col gap-1.5 shrink-0">
+      {/* Mode toggle */}
+      <div className="flex items-center gap-2">
+        <span className="text-[9px] font-bold text-amber-400 uppercase tracking-widest">Loop Preview</span>
+        <div className="flex rounded overflow-hidden border border-amber-700/40 ml-auto">
+          <button
+            className={`px-2 py-0.5 text-[9px] font-semibold transition-colors ${
+              loopPreviewMode === 'single'
+                ? 'bg-amber-700/60 text-amber-200'
+                : 'bg-transparent text-amber-500 hover:bg-amber-900/40'
+            }`}
+            onClick={() => setLoopPreviewMode('single')}
+          >
+            Single
+          </button>
+          <button
+            className={`px-2 py-0.5 text-[9px] font-semibold transition-colors ${
+              loopPreviewMode === 'range'
+                ? 'bg-amber-700/60 text-amber-200'
+                : 'bg-transparent text-amber-500 hover:bg-amber-900/40'
+            }`}
+            onClick={() => setLoopPreviewMode('range')}
+          >
+            Range
+          </button>
+        </div>
+      </div>
+
+      {loopPreviewMode === 'single' ? (
+        /* Single mode: slider + numeric input */
+        <div className="flex items-center gap-2">
+          <input
+            type="range"
+            min={rangeStart}
+            max={rangeEnd}
+            step={rangeStep}
+            value={loopPreviewValue}
+            onChange={(e) => setLoopPreviewValue(Number(e.target.value))}
+            className="flex-1 h-1.5 accent-amber-500 cursor-pointer"
+          />
+          <input
+            type="number"
+            min={rangeStart}
+            max={rangeEnd}
+            step={rangeStep}
+            value={loopPreviewValue}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              if (!isNaN(v)) setLoopPreviewValue(v)
+            }}
+            className="w-14 text-[10px] text-center bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-amber-200 focus:outline-none focus:border-amber-500"
+          />
+        </div>
+      ) : (
+        /* Range mode: start / end / step inputs */
+        <div className="flex items-center gap-1.5">
+          <label className="text-[9px] text-gray-400">start</label>
+          <input
+            type="number"
+            value={rangeStart}
+            step={1}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              if (!isNaN(v)) setLoopPreviewRange({ start: v, end: rangeEnd, step: rangeStep })
+            }}
+            className="w-14 text-[10px] text-center bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-amber-200 focus:outline-none focus:border-amber-500"
+          />
+          <label className="text-[9px] text-gray-400">end</label>
+          <input
+            type="number"
+            value={rangeEnd}
+            step={1}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              if (!isNaN(v)) setLoopPreviewRange({ start: rangeStart, end: v, step: rangeStep })
+            }}
+            className="w-14 text-[10px] text-center bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-amber-200 focus:outline-none focus:border-amber-500"
+          />
+          <label className="text-[9px] text-gray-400">step</label>
+          <input
+            type="number"
+            value={rangeStep}
+            step={0.1}
+            min={0.01}
+            onChange={(e) => {
+              const v = Number(e.target.value)
+              if (!isNaN(v) && v > 0) setLoopPreviewRange({ start: rangeStart, end: rangeEnd, step: v })
+            }}
+            className="w-14 text-[10px] text-center bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-amber-200 focus:outline-none focus:border-amber-500"
+          />
+        </div>
+      )}
+
+      {/* Iteration indicator */}
+      <div className="text-[9px] text-amber-600/70 font-mono">
+        {loopPreviewMode === 'single'
+          ? `i = ${loopPreviewValue}`
+          : `i = [${rangeStart} : ${rangeStep} : ${rangeEnd}]`
+        }
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/ModulePreviewArgs.tsx
+++ b/src/components/panels/ModulePreviewArgs.tsx
@@ -1,0 +1,104 @@
+/**
+ * F-002 R5: Module Argument Override UI
+ *
+ * Compact panel rendered inside the PreviewPanel when the active tab is a
+ * module. Shows each module_arg node's name and type with an editable value
+ * field. Changes trigger re-codegen and re-render via the store.
+ */
+import { useEditorStore } from '@/store/editorStore'
+
+export function ModulePreviewArgs() {
+  const tabs           = useEditorStore((s) => s.tabs)
+  const activeTabId    = useEditorStore((s) => s.activeTabId)
+  const nodes          = useEditorStore((s) => s.nodes)
+  const modulePreviewArgs    = useEditorStore((s) => s.modulePreviewArgs)
+  const setModulePreviewArgs = useEditorStore((s) => s.setModulePreviewArgs)
+
+  const activeTab = tabs.find((t) => t.id === activeTabId)
+
+  // Use live nodes (since the active tab's nodes are in state.nodes)
+  const argNodes = nodes.filter((n) => n.type === 'module_arg')
+
+  if (argNodes.length === 0) {
+    return (
+      <div className="px-3 py-2 border-b border-white/10 bg-purple-950/20 shrink-0">
+        <span className="text-[9px] text-purple-400/60 uppercase tracking-widest font-bold">
+          Module Preview
+        </span>
+        <p className="text-[10px] text-gray-500 mt-1">
+          Add <span className="font-mono text-purple-300">module_arg</span> nodes to expose parameters.
+        </p>
+      </div>
+    )
+  }
+
+  const handleChange = (argName: string, value: string) => {
+    setModulePreviewArgs({ ...modulePreviewArgs, [argName]: value })
+  }
+
+  const handleReset = () => {
+    const defaults: Record<string, string> = {}
+    for (const n of argNodes) {
+      const d = n.data as Record<string, unknown>
+      const name = String(d.argName || '')
+      if (name) defaults[name] = String(d.defaultValue ?? '0')
+    }
+    setModulePreviewArgs(defaults)
+  }
+
+  return (
+    <div className="px-3 py-2 border-b border-white/10 bg-purple-950/20 flex flex-col gap-1.5 shrink-0">
+      <div className="flex items-center gap-2">
+        <span className="text-[9px] font-bold text-purple-400 uppercase tracking-widest">
+          Module Preview — {activeTab?.label ?? ''}
+        </span>
+        <button
+          onClick={handleReset}
+          className="ml-auto text-[9px] text-gray-400 hover:text-white transition-colors px-1.5 py-0.5 rounded border border-gray-700 hover:border-gray-500"
+          title="Reset all args to defaults"
+        >
+          Reset
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {argNodes.map((n) => {
+          const d = n.data as Record<string, unknown>
+          const argName  = String(d.argName  || '')
+          const dataType = String(d.dataType || 'number')
+          const defaultVal = String(d.defaultValue ?? '0')
+          const currentVal = modulePreviewArgs[argName] ?? defaultVal
+
+          return (
+            <div key={n.id} className="flex items-center gap-1.5">
+              <span
+                className="text-[10px] text-gray-300 font-mono min-w-0 flex-1 truncate"
+                title={argName}
+              >
+                {argName}
+              </span>
+              <span className="text-[9px] text-gray-600 shrink-0">{dataType}</span>
+              {dataType === 'boolean' ? (
+                <select
+                  value={currentVal}
+                  onChange={(e) => handleChange(argName, e.target.value)}
+                  className="w-16 text-[10px] bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-purple-200 focus:outline-none focus:border-purple-500"
+                >
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select>
+              ) : (
+                <input
+                  type={dataType === 'number' ? 'number' : 'text'}
+                  value={currentVal}
+                  onChange={(e) => handleChange(argName, e.target.value)}
+                  className="w-20 text-[10px] text-right bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-purple-200 focus:outline-none focus:border-purple-500"
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/ModulePreviewArgs.tsx
+++ b/src/components/panels/ModulePreviewArgs.tsx
@@ -88,11 +88,14 @@ export function ModulePreviewArgs() {
                   <option value="false">false</option>
                 </select>
               ) : (
+                // Use text for all non-boolean types — numeric args can hold
+                // expression values (e.g. "WIDTH/2") that are invalid for
+                // <input type="number"> and would silently render as blank.
                 <input
-                  type={dataType === 'number' ? 'number' : 'text'}
+                  type="text"
                   value={currentVal}
                   onChange={(e) => handleChange(argName, e.target.value)}
-                  className="w-20 text-[10px] text-right bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-purple-200 focus:outline-none focus:border-purple-500"
+                  className="w-20 text-[10px] text-right bg-gray-800 border border-gray-700 rounded px-1 py-0.5 text-purple-200 focus:outline-none focus:border-purple-500 font-mono"
                 />
               )}
             </div>

--- a/src/components/panels/PreviewPanel.tsx
+++ b/src/components/panels/PreviewPanel.tsx
@@ -315,7 +315,7 @@ export function PreviewPanel() {
         )}
 
         {/* F-002 R6: no renderable geometry in the current scope */}
-        {!previewHasGeometry && renderStatus !== 'rendering' && (
+        {!previewHasGeometry && renderStatus !== 'rendering' && renderStatus !== 'error' && (
           <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-600 text-center px-6 z-10 bg-gray-900">
             <div className="text-4xl mb-3 opacity-20">∅</div>
             <p className="text-xs text-gray-500">No renderable geometry in this scope.</p>

--- a/src/components/panels/PreviewPanel.tsx
+++ b/src/components/panels/PreviewPanel.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { useEditorStore } from '@/store/editorStore'
 import { parseOFF } from '@/utils/parseOFF'
+import { LoopPreviewControls } from './LoopPreviewControls'
+import { ModulePreviewArgs } from './ModulePreviewArgs'
 
 // ─── Shared Three.js scene setup ─────────────────────────────────────────────
 
@@ -271,6 +273,17 @@ export function PreviewPanel() {
   const { renderStatus, renderError, renderLogs, renderResultSTL, renderResultPNG, renderResultOFF, previewMode, generatedCode } = useEditorStore()
   const hasColorHints = /\bcolor\s*\(/.test(generatedCode)
 
+  const tabs        = useEditorStore((s) => s.tabs)
+  const activeTabId = useEditorStore((s) => s.activeTabId)
+  const previewHasGeometry = useEditorStore((s) => s.previewHasGeometry)
+
+  const activeTabType = useMemo(() => {
+    return tabs.find((t) => t.id === activeTabId)?.tabType ?? 'main'
+  }, [tabs, activeTabId])
+
+  const isLoopTab   = activeTabType === 'loop'
+  const isModuleTab = activeTabType === 'module'
+
   return (
     <div className="h-full bg-gray-900 border-l border-white/10 flex flex-col">
       {/* Header */}
@@ -289,6 +302,10 @@ export function PreviewPanel() {
         </div>
       </div>
 
+      {/* F-002: Sub-editor controls */}
+      {isLoopTab   && <LoopPreviewControls />}
+      {isModuleTab && <ModulePreviewArgs />}
+
       {/* Content */}
       <div className="flex-1 relative overflow-hidden">
         {previewMode === 'stl' && hasColorHints && (
@@ -297,7 +314,21 @@ export function PreviewPanel() {
           </div>
         )}
 
-        {renderStatus === 'idle' && (
+        {/* F-002 R6: no renderable geometry in the current scope */}
+        {!previewHasGeometry && renderStatus !== 'rendering' && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-600 text-center px-6 z-10 bg-gray-900">
+            <div className="text-4xl mb-3 opacity-20">∅</div>
+            <p className="text-xs text-gray-500">No renderable geometry in this scope.</p>
+            {isLoopTab && (
+              <p className="text-[10px] text-gray-600 mt-1">Add geometry nodes to the loop body.</p>
+            )}
+            {isModuleTab && (
+              <p className="text-[10px] text-gray-600 mt-1">Add geometry nodes to the module body.</p>
+            )}
+          </div>
+        )}
+
+        {renderStatus === 'idle' && previewHasGeometry && (
           <div className="absolute inset-0 flex flex-col items-center justify-center text-gray-600 text-center px-6">
             <div className="text-5xl mb-4 opacity-30">◈</div>
             <p className="text-xs text-gray-500">Click <span className="text-white font-semibold">Render</span> or enable auto-render</p>

--- a/src/hooks/useCodegen.ts
+++ b/src/hooks/useCodegen.ts
@@ -1,26 +1,123 @@
 import { useEffect, useRef } from 'react'
 import { useEditorStore } from '@/store/editorStore'
-import { generateCode, generateModuleCode, generateLoopBodyCode } from '@/codegen'
+import {
+  generateCode,
+  generateModuleCode,
+  generateLoopBodyCode,
+  generateLoopPreviewCode,
+  generateModulePreviewCode,
+  hasRenderableGeometry,
+} from '@/codegen'
 
 const DEBOUNCE_MS = 150
 
+/** Node types that accept geometry on their in-0 handle (i.e. are "editor" loops). */
+const GEOMETRY_INPUT_LOOP_TYPES = new Set([
+  'for_loop',
+  'geo_editor_loop',
+])
+
 export function useCodegen() {
-  const nodes           = useEditorStore((s) => s.nodes)
-  const edges           = useEditorStore((s) => s.edges)
-  const tabs            = useEditorStore((s) => s.tabs)
-  const activeTabId     = useEditorStore((s) => s.activeTabId)
+  const nodes            = useEditorStore((s) => s.nodes)
+  const edges            = useEditorStore((s) => s.edges)
+  const tabs             = useEditorStore((s) => s.tabs)
+  const activeTabId      = useEditorStore((s) => s.activeTabId)
   const globalParameters = useEditorStore((s) => s.globalParameters)
-  const importedFiles   = useEditorStore((s) => s.importedFiles)
+  const importedFiles    = useEditorStore((s) => s.importedFiles)
   const setGeneratedCode = useEditorStore((s) => s.setGeneratedCode)
-  const timerRef        = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // F-002 preview state
+  const loopPreviewMode  = useEditorStore((s) => s.loopPreviewMode)
+  const loopPreviewValue = useEditorStore((s) => s.loopPreviewValue)
+  const loopPreviewRange = useEditorStore((s) => s.loopPreviewRange)
+  const modulePreviewArgs = useEditorStore((s) => s.modulePreviewArgs)
+  const setPreviewHasGeometry = useEditorStore((s) => s.setPreviewHasGeometry)
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (timerRef.current) clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => {
       const t0 = performance.now()
+      const activeTab = tabs.find((t) => t.id === activeTabId)
+
+      // ── F-002: Loop body tab preview ─────────────────────────────────────────
+      if (activeTab?.tabType === 'loop') {
+        if (!activeTab.parentTabId || !activeTab.parentNodeId) {
+          // Legacy tab without parent refs — fall back to bare module definition
+          // (old behaviour, no regression)
+          let fallback = ''
+          for (const tab of tabs) {
+            const isActiveTab = tab.id === activeTabId
+            const tabNodes = isActiveTab ? nodes : tab.nodes
+            const tabEdges = isActiveTab ? edges : tab.edges
+            if (tab.tabType === 'module') {
+              const mc = generateModuleCode(tab.moduleName, tabNodes, tabEdges)
+              if (mc.trim()) fallback += mc + '\n'
+            } else if (tab.tabType === 'loop') {
+              const lc = generateLoopBodyCode(tab.moduleName, tabNodes, tabEdges)
+              if (lc.trim()) fallback += lc + '\n'
+            }
+          }
+          setGeneratedCode(fallback)
+          setPreviewHasGeometry(hasRenderableGeometry(fallback))
+          return
+        }
+
+        // Find parent tab and node to determine geometry-input flag
+        const parentTab = tabs.find((t) => t.id === activeTab.parentTabId)
+        const parentTabNodes = parentTab?.id === activeTabId ? nodes : parentTab?.nodes ?? []
+        const parentNode = parentTabNodes.find((n) => n.id === activeTab.parentNodeId)
+        const hasGeometryInput = GEOMETRY_INPUT_LOOP_TYPES.has(parentNode?.type ?? '')
+
+        // Use active tab's live nodes/edges (state.nodes/edges is the active tab)
+        const previewCode = generateLoopPreviewCode({
+          bodyTabModuleName: activeTab.moduleName,
+          bodyTabNodes: nodes,
+          bodyTabEdges: edges,
+          parentTab: parentTab
+            ? { ...parentTab, nodes: parentTabNodes, edges: parentTab.edges }
+            : undefined,
+          parentNodeId: activeTab.parentNodeId,
+          hasGeometryInput,
+          previewMode: loopPreviewMode,
+          previewValue: loopPreviewValue,
+          previewRange: loopPreviewRange,
+          globalParameters,
+          tabs,
+          importedFiles,
+        })
+
+        setGeneratedCode(previewCode)
+        setPreviewHasGeometry(hasRenderableGeometry(previewCode))
+        console.log(
+          `[Botics] loop-preview codegen: ${(performance.now() - t0).toFixed(1)}ms, ${previewCode.length} chars`,
+        )
+        return
+      }
+
+      // ── F-002: Module tab preview ─────────────────────────────────────────────
+      if (activeTab?.tabType === 'module') {
+        const previewCode = generateModulePreviewCode({
+          moduleName: activeTab.moduleName,
+          moduleTabNodes: nodes,
+          moduleTabEdges: edges,
+          argOverrides: modulePreviewArgs,
+          globalParameters,
+          tabs,
+        })
+
+        setGeneratedCode(previewCode)
+        setPreviewHasGeometry(hasRenderableGeometry(previewCode))
+        console.log(
+          `[Botics] module-preview codegen: ${(performance.now() - t0).toFixed(1)}ms, ${previewCode.length} chars`,
+        )
+        return
+      }
+
+      // ── Standard codegen (main / sketch / other tabs) ─────────────────────────
       let fullCode = ''
 
-      // First, emit all module and loop body tab definitions (skip sketch tabs)
       for (const tab of tabs) {
         const isActiveTab = tab.id === activeTabId
         const tabNodes = isActiveTab ? nodes : tab.nodes
@@ -35,26 +132,35 @@ export function useCodegen() {
         }
       }
 
-      // Then emit the active tab's top-level code
-      const activeTab = tabs.find((t) => t.id === activeTabId)
-      if (activeTab && activeTab.tabType === 'sketch') {
+      if (activeTab?.tabType === 'sketch') {
         // Sketch tabs don't emit OpenSCAD — handled by useSketchCodegen
-      } else if (activeTab && activeTab.tabType === 'module') {
-        // Add a preview call so OpenSCAD renders the module's geometry
-        fullCode += `${activeTab.moduleName}();\n`
-      } else if (activeTab && activeTab.tabType === 'loop') {
-        // Loop body tabs don't emit a standalone call — for_loop nodes handle invocation
       } else {
         // Main or regular tabs
         fullCode += generateCode(nodes, edges, globalParameters, tabs, importedFiles)
       }
 
       setGeneratedCode(fullCode)
-      console.log(`[Botics] codegen: ${(performance.now() - t0).toFixed(1)}ms, ${fullCode.length} chars`)
+      setPreviewHasGeometry(true) // main tab always treated as geometry-bearing
+      console.log(
+        `[Botics] codegen: ${(performance.now() - t0).toFixed(1)}ms, ${fullCode.length} chars`,
+      )
     }, DEBOUNCE_MS)
 
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [nodes, edges, tabs, activeTabId, globalParameters, importedFiles, setGeneratedCode])
+  }, [
+    nodes,
+    edges,
+    tabs,
+    activeTabId,
+    globalParameters,
+    importedFiles,
+    setGeneratedCode,
+    loopPreviewMode,
+    loopPreviewValue,
+    loopPreviewRange,
+    modulePreviewArgs,
+    setPreviewHasGeometry,
+  ])
 }

--- a/src/nodes/control/FileIteratorLoopNode.tsx
+++ b/src/nodes/control/FileIteratorLoopNode.tsx
@@ -80,7 +80,7 @@ export function FileIteratorLoopNode({ id, data, selected }: NodeProps) {
         data: {},
       },
     ];
-    const newTabId = createLoopBodyTab(label, seedNodes as never);
+    const newTabId = createLoopBodyTab(label, seedNodes as never, undefined, callerTabId, id);
     updateNodeDataInTab(callerTabId, id, { bodyTabId: newTabId });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/nodes/control/ForLoopNode.tsx
+++ b/src/nodes/control/ForLoopNode.tsx
@@ -95,7 +95,7 @@ export function ForLoopNode({ id, data, selected }: NodeProps) {
       true,
       Date.now(),
     );
-    const newTabId = createLoopBodyTab(label, seedNodes as never);
+    const newTabId = createLoopBodyTab(label, seedNodes as never, undefined, callerTabId, id);
 
     updateNodeDataInTab(callerTabId, id, { bodyTabId: newTabId });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/nodes/control/GeometryEditorLoopNode.tsx
+++ b/src/nodes/control/GeometryEditorLoopNode.tsx
@@ -67,7 +67,7 @@ export function GeometryEditorLoopNode({ id, data, selected }: NodeProps) {
       true,
       Date.now(),
     );
-    const newTabId = createLoopBodyTab(label, seedNodes as never);
+    const newTabId = createLoopBodyTab(label, seedNodes as never, undefined, callerTabId, id);
     updateNodeDataInTab(callerTabId, id, { bodyTabId: newTabId });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/nodes/control/GeometryGeneratorLoopNode.tsx
+++ b/src/nodes/control/GeometryGeneratorLoopNode.tsx
@@ -67,7 +67,7 @@ export function GeometryGeneratorLoopNode({ id, data, selected }: NodeProps) {
       false,
       Date.now(),
     );
-    const newTabId = createLoopBodyTab(label, seedNodes as never);
+    const newTabId = createLoopBodyTab(label, seedNodes as never, undefined, callerTabId, id);
     updateNodeDataInTab(callerTabId, id, { bodyTabId: newTabId });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -363,6 +363,13 @@ export const useEditorStore = create<EditorState>()(
           }
 
           // ── F-002: Initialize preview state when entering a loop/module tab ──
+          // Strict numeric parse: only accept purely numeric strings.
+          // Expression values (e.g. "i*2", "WIDTH/2") fall back to the default.
+          function strictNum(v: unknown, fallback: number): number {
+            const n = Number(String(v ?? '').trim());
+            return Number.isFinite(n) ? n : fallback;
+          }
+
           // Clear stale state first
           state.loopPreviewMode = 'single';
           state.modulePreviewArgs = {};
@@ -377,9 +384,9 @@ export const useEditorStore = create<EditorState>()(
             const parentNode = parentNodes.find((n) => n.id === next.parentNodeId);
             if (parentNode) {
               const d = parentNode.data as Record<string, unknown>;
-              const startVal = parseFloat(String(d.start ?? 0)) || 0;
-              const endVal = parseFloat(String(d.end ?? 5)) || 5;
-              const stepVal = parseFloat(String(d.step ?? 1)) || 1;
+              const startVal = strictNum(d.start, 0);
+              const endVal   = strictNum(d.end,   5);
+              const stepVal  = strictNum(d.step,  1);
               state.loopPreviewValue = startVal;
               state.loopPreviewRange = { start: startVal, end: endVal, step: stepVal };
             } else {
@@ -391,9 +398,9 @@ export const useEditorStore = create<EditorState>()(
             const ctxNode = next.nodes.find((n) => n.type === 'loop_context');
             if (ctxNode) {
               const d = ctxNode.data as Record<string, unknown>;
-              const startVal = parseFloat(String(d.start ?? 0)) || 0;
-              const endVal = parseFloat(String(d.end ?? 5)) || 5;
-              const stepVal = parseFloat(String(d.step ?? 1)) || 1;
+              const startVal = strictNum(d.start, 0);
+              const endVal   = strictNum(d.end,   5);
+              const stepVal  = strictNum(d.step,  1);
               state.loopPreviewValue = startVal;
               state.loopPreviewRange = { start: startVal, end: endVal, step: stepVal };
             } else {
@@ -875,7 +882,7 @@ export const useEditorStore = create<EditorState>()(
                 const bodyTabId = d.bodyTabId as string | undefined;
                 if (!bodyTabId) continue;
                 const bodyTab = state.tabs.find((t) => t.id === bodyTabId);
-                if (bodyTab && !bodyTab.parentTabId) {
+                if (bodyTab && (!bodyTab.parentTabId || !bodyTab.parentNodeId)) {
                   bodyTab.parentTabId = tab.id;
                   bodyTab.parentNodeId = node.id;
                 }

--- a/src/store/editorStore.ts
+++ b/src/store/editorStore.ts
@@ -46,6 +46,10 @@ export interface EditorTab {
   sketchName: string; // Sketch identifier (for sketch tabs)
   nodes: Node[];
   edges: Edge[];
+  /** ID of the tab that created this sub-editor tab (F-002 R1) */
+  parentTabId?: string;
+  /** ID of the node in the parent tab that owns this sub-editor (F-002 R1) */
+  parentNodeId?: string;
 }
 
 function createTab(
@@ -109,6 +113,8 @@ interface EditorState {
     label: string,
     seedNodes: Node[],
     seedEdges?: import("@xyflow/react").Edge[],
+    parentTabId?: string,
+    parentNodeId?: string,
   ) => string;
   addNode: (node: Node) => void;
 
@@ -152,6 +158,18 @@ interface EditorState {
   setShowParametersPanel: (v: boolean) => void;
   setPreviewMode: (m: PreviewMode) => void;
   setAutoRender: (v: boolean) => void;
+
+  // ── Sub-editor preview state (F-002) ────────────────────────────────────────
+  loopPreviewMode: 'single' | 'range';
+  loopPreviewValue: number;
+  loopPreviewRange: { start: number; end: number; step: number } | null;
+  modulePreviewArgs: Record<string, string>;
+  previewHasGeometry: boolean;
+  setLoopPreviewMode: (mode: 'single' | 'range') => void;
+  setLoopPreviewValue: (v: number) => void;
+  setLoopPreviewRange: (r: { start: number; end: number; step: number } | null) => void;
+  setModulePreviewArgs: (args: Record<string, string>) => void;
+  setPreviewHasGeometry: (v: boolean) => void;
 
   // ── Sketch state (for active sketch tab) ──────────────────────────────────
   sketchPreviewSvg: string;
@@ -209,7 +227,7 @@ export const useEditorStore = create<EditorState>()(
         return id;
       },
 
-      createLoopBodyTab: (label, seedNodes, seedEdges) => {
+      createLoopBodyTab: (label, seedNodes, seedEdges, parentTabId, parentNodeId) => {
         const id = `tab-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         set((state) => {
           // Save current tab's nodes/edges without switching away
@@ -221,6 +239,8 @@ export const useEditorStore = create<EditorState>()(
           const tab = createTab(id, label, "loop");
           tab.nodes = seedNodes as Node[];
           tab.edges = (seedEdges ?? []) as Edge[];
+          if (parentTabId) tab.parentTabId = parentTabId;
+          if (parentNodeId) tab.parentNodeId = parentNodeId;
           state.tabs.push(tab);
           // activeTabId stays unchanged — silent creation
         });
@@ -340,6 +360,60 @@ export const useEditorStore = create<EditorState>()(
               .map((n) => `${n.type}=${JSON.stringify(n.data)}`)
               .join(" | ");
             console.log(`[Botics] tab-load "${next.label}": ${snapshot}`);
+          }
+
+          // ── F-002: Initialize preview state when entering a loop/module tab ──
+          // Clear stale state first
+          state.loopPreviewMode = 'single';
+          state.modulePreviewArgs = {};
+          state.previewHasGeometry = true;
+
+          if (next?.tabType === 'loop' && next.parentNodeId && next.parentTabId) {
+            // Find the parent for-loop node to read its range
+            const parentTab = state.tabs.find((t) => t.id === next.parentTabId);
+            const parentNodes = parentTab?.id === state.activeTabId
+              ? state.nodes
+              : parentTab?.nodes ?? [];
+            const parentNode = parentNodes.find((n) => n.id === next.parentNodeId);
+            if (parentNode) {
+              const d = parentNode.data as Record<string, unknown>;
+              const startVal = parseFloat(String(d.start ?? 0)) || 0;
+              const endVal = parseFloat(String(d.end ?? 5)) || 5;
+              const stepVal = parseFloat(String(d.step ?? 1)) || 1;
+              state.loopPreviewValue = startVal;
+              state.loopPreviewRange = { start: startVal, end: endVal, step: stepVal };
+            } else {
+              state.loopPreviewValue = 0;
+              state.loopPreviewRange = { start: 0, end: 5, step: 1 };
+            }
+          } else if (next?.tabType === 'loop') {
+            // Fallback: read from loop_context node in the body tab
+            const ctxNode = next.nodes.find((n) => n.type === 'loop_context');
+            if (ctxNode) {
+              const d = ctxNode.data as Record<string, unknown>;
+              const startVal = parseFloat(String(d.start ?? 0)) || 0;
+              const endVal = parseFloat(String(d.end ?? 5)) || 5;
+              const stepVal = parseFloat(String(d.step ?? 1)) || 1;
+              state.loopPreviewValue = startVal;
+              state.loopPreviewRange = { start: startVal, end: endVal, step: stepVal };
+            } else {
+              state.loopPreviewValue = 0;
+              state.loopPreviewRange = { start: 0, end: 5, step: 1 };
+            }
+          } else if (next?.tabType === 'module') {
+            // Initialize module arg overrides from module_arg nodes
+            const argNodes = next.nodes.filter((n) => n.type === 'module_arg');
+            const args: Record<string, string> = {};
+            for (const n of argNodes) {
+              const d = n.data as Record<string, unknown>;
+              const name = String(d.argName || '');
+              if (name) args[name] = String(d.defaultValue ?? '0');
+            }
+            state.modulePreviewArgs = args;
+            state.loopPreviewRange = null;
+          } else {
+            state.loopPreviewValue = 0;
+            state.loopPreviewRange = null;
           }
         }),
 
@@ -619,6 +693,24 @@ export const useEditorStore = create<EditorState>()(
           state.autoRender = v;
         }),
 
+      // ── Sub-editor preview state (F-002) ──────────────────────────────────────
+      loopPreviewMode: 'single',
+      loopPreviewValue: 0,
+      loopPreviewRange: null,
+      modulePreviewArgs: {},
+      previewHasGeometry: true,
+
+      setLoopPreviewMode: (mode) =>
+        set((state) => { state.loopPreviewMode = mode; }),
+      setLoopPreviewValue: (v) =>
+        set((state) => { state.loopPreviewValue = v; }),
+      setLoopPreviewRange: (r) =>
+        set((state) => { state.loopPreviewRange = r; }),
+      setModulePreviewArgs: (args) =>
+        set((state) => { state.modulePreviewArgs = args; }),
+      setPreviewHasGeometry: (v) =>
+        set((state) => { state.previewHasGeometry = v; }),
+
       // ── Sketch state ────────────────────────────────────────────────────────
       sketchPreviewSvg: "",
       setSketchPreviewSvg: (svg) =>
@@ -768,6 +860,26 @@ export const useEditorStore = create<EditorState>()(
             if (active) {
               state.nodes = active.nodes;
               state.edges = active.edges;
+            }
+
+            // ── F-002: Backfill parentTabId/parentNodeId for legacy saves ──────
+            // Scan all tabs for loop nodes that have bodyTabId references.
+            // For any loop tab that lacks parentTabId, set it from the owning node.
+            const loopNodeTypes = new Set([
+              'for_loop', 'geo_editor_loop', 'geo_generator_loop', 'file_iterator_loop',
+            ]);
+            for (const tab of state.tabs) {
+              for (const node of tab.nodes) {
+                if (!loopNodeTypes.has(node.type ?? '')) continue;
+                const d = node.data as Record<string, unknown>;
+                const bodyTabId = d.bodyTabId as string | undefined;
+                if (!bodyTabId) continue;
+                const bodyTab = state.tabs.find((t) => t.id === bodyTabId);
+                if (bodyTab && !bodyTab.parentTabId) {
+                  bodyTab.parentTabId = tab.id;
+                  bodyTab.parentNodeId = node.id;
+                }
+              }
             }
           } catch (err) {
             console.error("[importProject] Failed to parse:", err);


### PR DESCRIPTION
- R1: Add parentTabId/parentNodeId to EditorTab interface; update
  createLoopBodyTab to accept and store parent refs; backfill legacy
  saves in importProject; initialize loop/module preview state in
  setActiveTab.

- R1b: All loop node files (ForLoop, GeometryEditorLoop,
  GeometryGeneratorLoop, FileIteratorLoop) now pass callerTabId and
  nodeId to createLoopBodyTab so parent refs are always recorded.

- R2: generateLoopPreviewCode() synthesizes global params + body
  module definition + upstream geometry + invocation at a single
  iteration or range. emitUpstreamGeometry() walks the parent tab's
  graph to emit code flowing into a given input handle.

- R3: generateModulePreviewCode() synthesizes global params + module
  definition + a call with user-provided argument overrides (falling
  back to module_arg node defaults).

- R4: New LoopPreviewControls component — horizontal control bar in
  PreviewPanel header for loop tabs; mode toggle (Single/Range),
  bounded slider + numeric input, start/end/step fields for range mode.

- R5: New ModulePreviewArgs component — compact arg override panel in
  PreviewPanel for module tabs; per-arg editable fields, Reset button.

- R6: useCodegen hook branches on active tab type — loop tabs use
  generateLoopPreviewCode, module tabs use generateModulePreviewCode,
  all paths call hasRenderableGeometry and update previewHasGeometry.
  hasRenderableGeometry() filters out declarations/module defs/echo
  to determine if code will produce visible output.

- PreviewPanel mounts LoopPreviewControls (loop tabs) and
  ModulePreviewArgs (module tabs), and shows an empty-scope overlay
  (R6) when previewHasGeometry is false.

https://claude.ai/code/session_01NALnWY3EFJiH7gRw9BRGdE