### PR TITLE
Prevent duplicate vector-effect attributes in SVG paths

### DIFF
--- a/src/codegen/sketchCodegen.ts
+++ b/src/codegen/sketchCodegen.ts
@@ -741,5 +741,5 @@ export function generateSketchSvg(model: makerjs.IModel): string {
     useSvgPathOnly: true,
   })
   // Add non-scaling strokes so lines stay crisp regardless of zoom level
-  return svg.replace(/<path /g, '<path vector-effect="non-scaling-stroke" ')
+  return svg.replace(/<path (?!.*vector-effect)/g, '<path vector-effect="non-scaling-stroke" ')
 }


### PR DESCRIPTION
## Summary
Updated the SVG path regex replacement logic to avoid adding duplicate `vector-effect="non-scaling-stroke"` attributes to paths that already have this attribute.

## Key Changes
- Modified the regex pattern in `generateSketchSvg()` from `/<path /g` to `/<path (?!.*vector-effect)/g`
- The new negative lookahead pattern ensures the replacement only occurs on `<path` tags that don't already contain a `vector-effect` attribute
- This prevents malformed SVG output when paths are processed multiple times or already include the non-scaling-stroke effect

## Implementation Details
The change uses a negative lookahead assertion `(?!.*vector-effect)` to check that the `vector-effect` attribute is not present before applying the replacement. This is a more robust approach than the previous blanket replacement, which could result in duplicate attributes in certain scenarios.

https://claude.ai/code/session_01FVFoepchKt9vKx4tMDayLV