### PR TITLE
feat(F-005): keyboard navigation between nodes in the node editor

### DIFF
--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -189,8 +189,15 @@ export function EditorPanel() {
               { type: "select" as const, id: currentId, selected: false },
             ]);
           }
-          // Visually highlight the edge via XYFlow selection
+          // Clear any existing edge selection first so the focused edge is
+          // the only visually highlighted one (guards against Shift-click
+          // multi-selection leaving stale selected edges).
+          const selectedEdgeChanges = edges
+            .filter((e) => e.selected)
+            .map((e) => ({ type: "select" as const, id: e.id, selected: false }));
+          // Visually highlight the focused edge via XYFlow selection
           onEdgesChange([
+            ...selectedEdgeChanges,
             { type: "select" as const, id: outputEdge.id, selected: true },
           ]);
           setFocusedEdgeId(outputEdge.id);
@@ -215,10 +222,16 @@ export function EditorPanel() {
               .measured as { width?: number; height?: number } | undefined;
             const w = measured?.width ?? 200;
             const h = measured?.height ?? 150;
+            // Use absolute flow position so grouped nodes (which store
+            // position relative to their parent) are placed correctly.
+            const srcExt = sourceNode as typeof sourceNode & {
+              positionAbsolute?: { x: number; y: number };
+            };
+            const absolutePos = srcExt.positionAbsolute ?? sourceNode.position;
             // Position dropdown just to the right of the source node's output
             const screenPos = rfInstance.current.flowToScreenPosition({
-              x: sourceNode.position.x + w + 24,
-              y: sourceNode.position.y + h / 2 - 20,
+              x: absolutePos.x + w + 24,
+              y: absolutePos.y + h / 2 - 20,
             });
             setQuickInsert({
               edgeId: focusedEdgeId,
@@ -318,18 +331,64 @@ export function EditorPanel() {
         return;
       }
 
-      // Position: midpoint between source and target, or offset from source
-      let newX: number;
-      let newY: number;
-      if (targetNode) {
-        newX = (sourceNode.position.x + targetNode.position.x) / 2;
-        newY = (sourceNode.position.y + targetNode.position.y) / 2;
+      // Helper: resolve the absolute flow-coordinate position of a node.
+      // Grouped nodes store position relative to their parentId; we use
+      // positionAbsolute (maintained by XYFlow internally) when available,
+      // and fall back to walking the parent chain otherwise.
+      const getAbsolutePosition = (n: Node): { x: number; y: number } => {
+        const nExt = n as Node & {
+          positionAbsolute?: { x: number; y: number };
+        };
+        if (nExt.positionAbsolute) return nExt.positionAbsolute;
+        let x = n.position.x;
+        let y = n.position.y;
+        let pid = n.parentId;
+        while (pid) {
+          const p = rfInstance.current?.getNode(pid);
+          if (!p) break;
+          x += p.position.x;
+          y += p.position.y;
+          pid = p.parentId;
+        }
+        return { x, y };
+      };
+
+      const srcAbsolute = getAbsolutePosition(sourceNode);
+      const tgtAbsolute = targetNode ? getAbsolutePosition(targetNode) : null;
+
+      // Compute insertion point in absolute flow coordinates
+      let newAbsX: number;
+      let newAbsY: number;
+      if (tgtAbsolute) {
+        newAbsX = (srcAbsolute.x + tgtAbsolute.x) / 2;
+        newAbsY = (srcAbsolute.y + tgtAbsolute.y) / 2;
       } else {
         const measured = (sourceNode as Record<string, unknown>).measured as
           | { width?: number }
           | undefined;
-        newX = sourceNode.position.x + (measured?.width ?? 200) + 120;
-        newY = sourceNode.position.y;
+        newAbsX = srcAbsolute.x + (measured?.width ?? 200) + 120;
+        newAbsY = srcAbsolute.y;
+      }
+
+      // Assign to a parent group when source and target share one, or when
+      // only the source is in a group and there is no target.
+      const newParentId: string | undefined =
+        targetNode && sourceNode.parentId === targetNode.parentId
+          ? sourceNode.parentId
+          : !targetNode
+            ? sourceNode.parentId
+            : undefined;
+
+      // Convert absolute coords back to parent-relative if needed
+      let newX = newAbsX;
+      let newY = newAbsY;
+      if (newParentId) {
+        const parentNode = rfInstance.current.getNode(newParentId);
+        if (parentNode) {
+          const parentAbsolute = getAbsolutePosition(parentNode);
+          newX = newAbsX - parentAbsolute.x;
+          newY = newAbsY - parentAbsolute.y;
+        }
       }
 
       const newNodeId = `${item.type}-${nodeIdCounter++}`;
@@ -338,6 +397,7 @@ export function EditorPanel() {
         type: item.type,
         position: { x: newX, y: newY },
         data: { ...item.defaultData },
+        ...(newParentId ? { parentId: newParentId } : {}),
       };
 
       // Remove the original edge

--- a/src/components/panels/EditorPanel.tsx
+++ b/src/components/panels/EditorPanel.tsx
@@ -19,13 +19,25 @@ import { PACK_PALETTE_ITEMS } from "@/nodepacks";
 import { DeletableEdge } from "@/components/DeletableEdge";
 import { SearchBar } from "@/components/SearchBar";
 import { ContextMenu } from "@/components/panels/ContextMenu";
+import { QuickInsertDropdown } from "@/components/panels/QuickInsertDropdown";
 import { computeDownstreamOfHalts } from "@/utils/haltGraph";
 import { HaltDimmedContext } from "@/contexts/HaltDimmedContext";
+import { useGraphNavigation } from "@/hooks/useGraphNavigation";
 
 const edgeTypes = { default: DeletableEdge };
 const ALL_PALETTE_ITEMS = [...PALETTE_ITEMS, ...PACK_PALETTE_ITEMS];
 
 let nodeIdCounter = 1;
+
+/** State for the F-005 quick-insert popup (R5). */
+interface QuickInsertState {
+  /** The focused edge that triggered the insert. */
+  edgeId: string;
+  /** Screen-space X for positioning the dropdown. */
+  screenX: number;
+  /** Screen-space Y for positioning the dropdown. */
+  screenY: number;
+}
 
 export function EditorPanel() {
   const { nodes, edges, onNodesChange, onEdgesChange, onConnect, addNode } =
@@ -35,7 +47,25 @@ export function EditorPanel() {
   const toggleNodeHalted = useEditorStore((s) => s.toggleNodeHalted);
   const rfInstance = useRef<ReactFlowInstance | null>(null);
 
-  // Compute downstream dimmed set
+  // ── F-005: Keyboard navigation state ───────────────────────────────────────
+  /**
+   * When non-null, the user has pressed SHIFT+TAB to "focus" an output edge.
+   * SPACE will then open the quick-insert dropdown.
+   * ESC will return focus to the edge's source node.
+   */
+  const [focusedEdgeId, setFocusedEdgeId] = useState<string | null>(null);
+  /** When non-null, the quick-insert dropdown is visible. */
+  const [quickInsert, setQuickInsert] = useState<QuickInsertState | null>(null);
+
+  const {
+    navigateDownstream,
+    navigateUpstream,
+    getSelectedNodeId,
+    getOutputEdgeOfSelected,
+    selectNode,
+  } = useGraphNavigation({ nodes, edges, onNodesChange, rfInstance });
+
+  // ── Downstream dim computation ─────────────────────────────────────────────
   const dimmedNodeIds = useMemo(() => {
     const haltedIds = nodes
       .filter((n) => (n.data as Record<string, unknown>)._halted)
@@ -84,14 +114,142 @@ export function EditorPanel() {
     [addNode],
   );
 
-  // Keyboard handler for node/edge deletion, grouping, and halt toggle
+  // ── Keyboard handler ────────────────────────────────────────────────────────
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       const target = event.target as HTMLElement;
       const isInputFocused =
         target.tagName === "INPUT" ||
         target.tagName === "TEXTAREA" ||
-        target.tagName === "SELECT";
+        target.tagName === "SELECT" ||
+        target.isContentEditable;
+
+      // ── F-005 R1: SHIFT+RIGHT — navigate downstream ──────────────────────
+      if (
+        event.key === "ArrowRight" &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !isInputFocused
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        // Clear any edge-focus mode before navigating
+        if (focusedEdgeId) {
+          onEdgesChange([
+            { type: "select" as const, id: focusedEdgeId, selected: false },
+          ]);
+          setFocusedEdgeId(null);
+        }
+        setQuickInsert(null);
+        navigateDownstream();
+        return;
+      }
+
+      // ── F-005 R2: SHIFT+LEFT — navigate upstream ─────────────────────────
+      if (
+        event.key === "ArrowLeft" &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !isInputFocused
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (focusedEdgeId) {
+          onEdgesChange([
+            { type: "select" as const, id: focusedEdgeId, selected: false },
+          ]);
+          setFocusedEdgeId(null);
+        }
+        setQuickInsert(null);
+        navigateUpstream();
+        return;
+      }
+
+      // ── F-005 R4: SHIFT+TAB — jump focus to the node's output edge ───────
+      if (
+        event.key === "Tab" &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !isInputFocused
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const outputEdge = getOutputEdgeOfSelected();
+        if (outputEdge) {
+          // Deselect the current node
+          const currentId = getSelectedNodeId();
+          if (currentId) {
+            onNodesChange([
+              { type: "select" as const, id: currentId, selected: false },
+            ]);
+          }
+          // Visually highlight the edge via XYFlow selection
+          onEdgesChange([
+            { type: "select" as const, id: outputEdge.id, selected: true },
+          ]);
+          setFocusedEdgeId(outputEdge.id);
+          setQuickInsert(null);
+        }
+        return;
+      }
+
+      // ── F-005 R5: SPACE — open quick-insert when an edge is focused ───────
+      if (
+        event.key === " " &&
+        focusedEdgeId &&
+        !isInputFocused
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const edge = edges.find((e) => e.id === focusedEdgeId);
+        if (edge && rfInstance.current) {
+          const sourceNode = rfInstance.current.getNode(edge.source);
+          if (sourceNode) {
+            const measured = (sourceNode as Record<string, unknown>)
+              .measured as { width?: number; height?: number } | undefined;
+            const w = measured?.width ?? 200;
+            const h = measured?.height ?? 150;
+            // Position dropdown just to the right of the source node's output
+            const screenPos = rfInstance.current.flowToScreenPosition({
+              x: sourceNode.position.x + w + 24,
+              y: sourceNode.position.y + h / 2 - 20,
+            });
+            setQuickInsert({
+              edgeId: focusedEdgeId,
+              screenX: screenPos.x,
+              screenY: screenPos.y,
+            });
+          }
+        }
+        return;
+      }
+
+      // ── F-005: ESC — dismiss quick-insert or return from edge-focus mode ──
+      if (event.key === "Escape") {
+        if (quickInsert) {
+          setQuickInsert(null);
+          return;
+        }
+        if (focusedEdgeId) {
+          const edge = edges.find((e) => e.id === focusedEdgeId);
+          // Deselect the edge
+          onEdgesChange([
+            { type: "select" as const, id: focusedEdgeId, selected: false },
+          ]);
+          setFocusedEdgeId(null);
+          // Re-select the edge's source node
+          if (edge) selectNode(edge.source);
+          return;
+        }
+      }
+
+      // ── Existing shortcuts ─────────────────────────────────────────────────
 
       if (event.key === "Delete" || event.key === "Backspace") {
         // Don't delete if an input is focused
@@ -100,11 +258,13 @@ export function EditorPanel() {
         }
         // ReactFlow handles this via onNodesChange/onEdgesChange with remove changes
       }
+
       // Ctrl+G: group selected nodes
       if ((event.ctrlKey || event.metaKey) && event.key === "g") {
         event.preventDefault();
         groupSelectedNodes();
       }
+
       // H: toggle halt on selected nodes
       if (
         event.key === "h" &&
@@ -121,7 +281,94 @@ export function EditorPanel() {
         }
       }
     },
-    [groupSelectedNodes, toggleNodeHalted],
+    [
+      groupSelectedNodes,
+      toggleNodeHalted,
+      navigateDownstream,
+      navigateUpstream,
+      getOutputEdgeOfSelected,
+      getSelectedNodeId,
+      onNodesChange,
+      onEdgesChange,
+      edges,
+      focusedEdgeId,
+      quickInsert,
+      selectNode,
+    ],
+  );
+
+  // ── Quick-insert handler (F-005 R5) ─────────────────────────────────────────
+  const handleQuickInsert = useCallback(
+    (item: (typeof ALL_PALETTE_ITEMS)[number]) => {
+      if (!quickInsert || !rfInstance.current) return;
+
+      const edge = edges.find((e) => e.id === quickInsert.edgeId);
+      if (!edge) {
+        setQuickInsert(null);
+        setFocusedEdgeId(null);
+        return;
+      }
+
+      const sourceNode = rfInstance.current.getNode(edge.source);
+      const targetNode = rfInstance.current.getNode(edge.target);
+
+      if (!sourceNode) {
+        setQuickInsert(null);
+        setFocusedEdgeId(null);
+        return;
+      }
+
+      // Position: midpoint between source and target, or offset from source
+      let newX: number;
+      let newY: number;
+      if (targetNode) {
+        newX = (sourceNode.position.x + targetNode.position.x) / 2;
+        newY = (sourceNode.position.y + targetNode.position.y) / 2;
+      } else {
+        const measured = (sourceNode as Record<string, unknown>).measured as
+          | { width?: number }
+          | undefined;
+        newX = sourceNode.position.x + (measured?.width ?? 200) + 120;
+        newY = sourceNode.position.y;
+      }
+
+      const newNodeId = `${item.type}-${nodeIdCounter++}`;
+      const newNode: Node = {
+        id: newNodeId,
+        type: item.type,
+        position: { x: newX, y: newY },
+        data: { ...item.defaultData },
+      };
+
+      // Remove the original edge
+      onEdgesChange([{ type: "remove" as const, id: edge.id }]);
+
+      // Add the new node
+      addNode(newNode);
+
+      // Wire source → new node
+      onConnect({
+        source: edge.source,
+        target: newNodeId,
+        sourceHandle: edge.sourceHandle ?? null,
+        targetHandle: null,
+      });
+
+      // Wire new node → original target
+      onConnect({
+        source: newNodeId,
+        target: edge.target,
+        sourceHandle: null,
+        targetHandle: edge.targetHandle ?? null,
+      });
+
+      // Select the newly inserted node
+      selectNode(newNodeId);
+
+      setQuickInsert(null);
+      setFocusedEdgeId(null);
+    },
+    [quickInsert, edges, rfInstance, onEdgesChange, addNode, onConnect, selectNode],
   );
 
   const onMoveEnd = useCallback(
@@ -131,16 +378,19 @@ export function EditorPanel() {
     [setLastViewport],
   );
 
-  const onContextMenu = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    // If already shown via long-press (iPadOS 16+ fires contextmenu after long-press too)
-    if (contextMenu) return;
-    const selected = useEditorStore.getState().nodes.filter((n) => n.selected);
-    if (selected.length < 2) return;
-    setContextMenu({ x: e.clientX, y: e.clientY });
-  }, [contextMenu]);
+  const onContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (contextMenu) return;
+      const selected = useEditorStore
+        .getState()
+        .nodes.filter((n) => n.selected);
+      if (selected.length < 2) return;
+      setContextMenu({ x: e.clientX, y: e.clientY });
+    },
+    [contextMenu],
+  );
 
-  // Long-press on the canvas shows the context menu on touch devices
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onCanvasTouchStart = useCallback((e: React.TouchEvent) => {
@@ -159,7 +409,6 @@ export function EditorPanel() {
     }
   }, []);
 
-  // Clean up timer on unmount
   useEffect(() => cancelLongPress, [cancelLongPress]);
 
   return (
@@ -267,6 +516,17 @@ export function EditorPanel() {
             y={contextMenu.y}
             onGroupNodes={groupSelectedNodes}
             onClose={() => setContextMenu(null)}
+          />
+        )}
+
+        {/* F-005 R5: Quick-insert dropdown */}
+        {quickInsert && (
+          <QuickInsertDropdown
+            screenX={quickInsert.screenX}
+            screenY={quickInsert.screenY}
+            paletteItems={ALL_PALETTE_ITEMS}
+            onInsert={handleQuickInsert}
+            onClose={() => setQuickInsert(null)}
           />
         )}
 

--- a/src/components/panels/QuickInsertDropdown.tsx
+++ b/src/components/panels/QuickInsertDropdown.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { PaletteItem } from "@/types/nodes";
+import { CATEGORY_COLORS, CATEGORY_TEXT } from "@/types/nodes";
+import {
+  PACK_CATEGORY_COLORS,
+  PACK_CATEGORY_TEXT,
+} from "@/nodepacks";
+
+// Merge core + pack category styling (same pattern as NodePalette)
+const ALL_CATEGORY_COLORS: Record<string, string> = {
+  ...CATEGORY_COLORS,
+  ...PACK_CATEGORY_COLORS,
+};
+const ALL_CATEGORY_TEXT: Record<string, string> = {
+  ...CATEGORY_TEXT,
+  ...PACK_CATEGORY_TEXT,
+};
+
+interface QuickInsertDropdownProps {
+  /** Screen-space X coordinate (left edge of popup). */
+  screenX: number;
+  /** Screen-space Y coordinate (top edge of popup). */
+  screenY: number;
+  /** Full list of palette items to search against. */
+  paletteItems: PaletteItem[];
+  /** Called when the user selects a node type to insert. */
+  onInsert: (item: PaletteItem) => void;
+  /** Called when the dropdown should close without inserting. */
+  onClose: () => void;
+}
+
+/**
+ * F-005 R5: Filterable quick-insert dropdown.
+ *
+ * Opened by pressing SPACE on a focused output edge. Shows a searchable list
+ * of all palette node types. Keyboard-navigable with arrow keys, Enter to
+ * confirm, Escape to cancel.
+ *
+ * Positioning: placed at the supplied screen coordinates, clamped to stay
+ * within the viewport.
+ */
+export function QuickInsertDropdown({
+  screenX,
+  screenY,
+  paletteItems,
+  onInsert,
+  onClose,
+}: QuickInsertDropdownProps) {
+  const [query, setQuery] = useState("");
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = paletteItems.filter(
+    (item) =>
+      item.label.toLowerCase().includes(query.toLowerCase()) ||
+      item.type.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  // Reset keyboard highlight when the filter changes
+  useEffect(() => {
+    setHighlightIndex(0);
+  }, [query]);
+
+  // Auto-focus the search input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Keep the highlighted list item scrolled into view
+  useEffect(() => {
+    const el = listRef.current?.children[highlightIndex] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex]);
+
+  // Close when the user clicks outside the dropdown
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        onClose();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setHighlightIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setHighlightIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const item = filtered[highlightIndex];
+        if (item) onInsert(item);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+      // Stop propagation so the canvas onKeyDown doesn't also fire
+      e.stopPropagation();
+    },
+    [filtered, highlightIndex, onInsert, onClose],
+  );
+
+  // Clamp position so the dropdown stays within the viewport
+  const POPUP_W = 224; // w-56
+  const POPUP_H = 320; // approx max-h
+  const left = Math.min(screenX, window.innerWidth - POPUP_W - 8);
+  const top = Math.min(screenY, window.innerHeight - POPUP_H - 8);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ left, top }}
+      className="fixed z-50 w-56 bg-gray-900 border border-white/20 rounded-lg shadow-2xl overflow-hidden"
+      // Prevent mouse-down from blurring the canvas or triggering edge/node
+      // deselect inside ReactFlow
+      onMouseDown={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {/* Search input */}
+      <div className="p-2 border-b border-white/10">
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Insert node..."
+          className="w-full bg-gray-800 text-white text-xs rounded px-2 py-1.5 outline-none placeholder-gray-500 font-mono"
+        />
+      </div>
+
+      {/* Node list */}
+      <ul ref={listRef} className="max-h-60 overflow-y-auto py-1">
+        {filtered.length === 0 ? (
+          <li className="px-3 py-2 text-xs text-gray-500 text-center">
+            No matches
+          </li>
+        ) : (
+          filtered.map((item, i) => (
+            <li
+              key={item.type}
+              className={`
+                px-3 py-1.5 text-xs cursor-pointer flex items-center gap-2
+                transition-colors
+                ${i === highlightIndex ? "bg-gray-700" : "hover:bg-gray-800"}
+              `}
+              onMouseEnter={() => setHighlightIndex(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onInsert(item);
+              }}
+            >
+              <span
+                className={`
+                  ${ALL_CATEGORY_COLORS[item.category] ?? "bg-gray-600"}
+                  ${ALL_CATEGORY_TEXT[item.category] ?? "text-white"}
+                  rounded px-1.5 py-0.5 text-[9px] font-medium shrink-0
+                `}
+              >
+                {item.label}
+              </span>
+            </li>
+          ))
+        )}
+      </ul>
+
+      {/* Keyboard hint */}
+      <div className="px-3 py-1.5 border-t border-white/10 flex gap-3 text-[9px] text-gray-600">
+        <span>
+          <kbd className="font-mono">↑↓</kbd> navigate
+        </span>
+        <span>
+          <kbd className="font-mono">↵</kbd> insert
+        </span>
+        <span>
+          <kbd className="font-mono">Esc</kbd> cancel
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/panels/QuickInsertDropdown.tsx
+++ b/src/components/panels/QuickInsertDropdown.tsx
@@ -94,9 +94,13 @@ export function QuickInsertDropdown({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "ArrowDown") {
         e.preventDefault();
+        e.stopPropagation();
+        if (filtered.length === 0) return;
         setHighlightIndex((i) => Math.min(i + 1, filtered.length - 1));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
+        e.stopPropagation();
+        if (filtered.length === 0) return;
         setHighlightIndex((i) => Math.max(i - 1, 0));
       } else if (e.key === "Enter") {
         e.preventDefault();
@@ -115,8 +119,8 @@ export function QuickInsertDropdown({
   // Clamp position so the dropdown stays within the viewport
   const POPUP_W = 224; // w-56
   const POPUP_H = 320; // approx max-h
-  const left = Math.min(screenX, window.innerWidth - POPUP_W - 8);
-  const top = Math.min(screenY, window.innerHeight - POPUP_H - 8);
+  const left = Math.max(8, Math.min(screenX, window.innerWidth - POPUP_W - 8));
+  const top = Math.max(8, Math.min(screenY, window.innerHeight - POPUP_H - 8));
 
   return (
     <div

--- a/src/hooks/useGraphNavigation.ts
+++ b/src/hooks/useGraphNavigation.ts
@@ -1,0 +1,194 @@
+import { useCallback } from "react";
+import type { Node, Edge, NodeChange, ReactFlowInstance } from "@xyflow/react";
+import type React from "react";
+
+interface UseGraphNavigationOptions {
+  nodes: Node[];
+  edges: Edge[];
+  onNodesChange: (changes: NodeChange[]) => void;
+  rfInstance: React.RefObject<ReactFlowInstance | null>;
+}
+
+/**
+ * F-005: Keyboard navigation between nodes in the node graph.
+ *
+ * Provides SHIFT+RIGHT (downstream) and SHIFT+LEFT (upstream) traversal
+ * with wrap-around at chain termini, plus helpers for edge-focus mode.
+ *
+ * Graph terminology:
+ *   upstream   = toward source primitives (edge.source side)
+ *   downstream = toward render output    (edge.target side)
+ *
+ * "Primary" connection = first edge found in the edges array matching the
+ * source or target — consistent with the spec's "first/default handle" rule.
+ */
+export function useGraphNavigation({
+  nodes,
+  edges,
+  onNodesChange,
+  rfInstance,
+}: UseGraphNavigationOptions) {
+  // ── Viewport helpers ──────────────────────────────────────────────────────
+
+  /** Pan the canvas to center on a node without changing the zoom level. */
+  const scrollNodeIntoView = useCallback(
+    (nodeId: string) => {
+      if (!rfInstance.current) return;
+      const node = rfInstance.current.getNode(nodeId);
+      if (!node) return;
+      // XYFlow v12 stores actual DOM dimensions under `measured`
+      const measured = (node as Record<string, unknown>).measured as
+        | { width?: number; height?: number }
+        | undefined;
+      const w = measured?.width ?? 200;
+      const h = measured?.height ?? 150;
+      rfInstance.current.setCenter(
+        node.position.x + w / 2,
+        node.position.y + h / 2,
+        { duration: 300 },
+      );
+    },
+    [rfInstance],
+  );
+
+  // ── Selection helpers ─────────────────────────────────────────────────────
+
+  /**
+   * Deselect all currently selected nodes, select targetId, scroll into view.
+   * Uses onNodesChange so XYFlow keeps its internal selection state in sync.
+   */
+  const selectNode = useCallback(
+    (targetId: string) => {
+      const changes: NodeChange[] = nodes
+        .filter((n) => n.selected)
+        .map((n) => ({ type: "select" as const, id: n.id, selected: false }));
+      changes.push({ type: "select" as const, id: targetId, selected: true });
+      onNodesChange(changes);
+      scrollNodeIntoView(targetId);
+    },
+    [nodes, onNodesChange, scrollNodeIntoView],
+  );
+
+  /**
+   * Returns the id of the currently selected node, or null if nothing is
+   * selected or multiple nodes are selected.
+   */
+  const getSelectedNodeId = useCallback((): string | null => {
+    const selected = nodes.filter((n) => n.selected);
+    return selected.length === 1 ? selected[0].id : null;
+  }, [nodes]);
+
+  // ── Graph adjacency ───────────────────────────────────────────────────────
+
+  /** Primary downstream neighbour: first edge where source === nodeId. */
+  const getDownstreamId = useCallback(
+    (nodeId: string): string | null =>
+      edges.find((e) => e.source === nodeId)?.target ?? null,
+    [edges],
+  );
+
+  /** Primary upstream neighbour: first edge where target === nodeId. */
+  const getUpstreamId = useCallback(
+    (nodeId: string): string | null =>
+      edges.find((e) => e.target === nodeId)?.source ?? null,
+    [edges],
+  );
+
+  /**
+   * Walk upstream along primary edges to find the chain terminus —
+   * the node with no upstream connection. Cycle-safe via visited set.
+   */
+  const findChainStart = useCallback(
+    (nodeId: string): string => {
+      const visited = new Set<string>();
+      let current = nodeId;
+      for (;;) {
+        if (visited.has(current)) break; // cycle guard
+        visited.add(current);
+        const up = getUpstreamId(current);
+        if (!up) break;
+        current = up;
+      }
+      return current;
+    },
+    [getUpstreamId],
+  );
+
+  /**
+   * Walk downstream along primary edges to find the chain terminus —
+   * the node with no downstream connection. Cycle-safe via visited set.
+   */
+  const findChainEnd = useCallback(
+    (nodeId: string): string => {
+      const visited = new Set<string>();
+      let current = nodeId;
+      for (;;) {
+        if (visited.has(current)) break; // cycle guard
+        visited.add(current);
+        const down = getDownstreamId(current);
+        if (!down) break;
+        current = down;
+      }
+      return current;
+    },
+    [getDownstreamId],
+  );
+
+  // ── Navigation actions ────────────────────────────────────────────────────
+
+  /**
+   * R1 + R3: SHIFT+RIGHT — move to primary downstream node.
+   * At the downstream terminus, wraps back to the chain start.
+   */
+  const navigateDownstream = useCallback(() => {
+    const currentId = getSelectedNodeId();
+    if (!currentId) return;
+    const nextId = getDownstreamId(currentId);
+    if (nextId) {
+      selectNode(nextId);
+    } else {
+      // Wrap: jump to chain start
+      const start = findChainStart(currentId);
+      if (start !== currentId) selectNode(start);
+    }
+  }, [getSelectedNodeId, getDownstreamId, selectNode, findChainStart]);
+
+  /**
+   * R2 + R3: SHIFT+LEFT — move to primary upstream node.
+   * At the upstream terminus, wraps forward to the chain end.
+   */
+  const navigateUpstream = useCallback(() => {
+    const currentId = getSelectedNodeId();
+    if (!currentId) return;
+    const prevId = getUpstreamId(currentId);
+    if (prevId) {
+      selectNode(prevId);
+    } else {
+      // Wrap: jump to chain end
+      const end = findChainEnd(currentId);
+      if (end !== currentId) selectNode(end);
+    }
+  }, [getSelectedNodeId, getUpstreamId, selectNode, findChainEnd]);
+
+  /**
+   * R4: Returns the first output edge from the currently selected node, or
+   * null if no node is selected or it has no outgoing connections.
+   * Used by SHIFT+TAB to identify which edge to focus.
+   */
+  const getOutputEdgeOfSelected = useCallback((): Edge | null => {
+    const currentId = getSelectedNodeId();
+    if (!currentId) return null;
+    return edges.find((e) => e.source === currentId) ?? null;
+  }, [getSelectedNodeId, edges]);
+
+  return {
+    navigateDownstream,
+    navigateUpstream,
+    getSelectedNodeId,
+    getDownstreamId,
+    getUpstreamId,
+    getOutputEdgeOfSelected,
+    scrollNodeIntoView,
+    selectNode,
+  };
+}

--- a/src/hooks/useGraphNavigation.ts
+++ b/src/hooks/useGraphNavigation.ts
@@ -42,9 +42,35 @@ export function useGraphNavigation({
         | undefined;
       const w = measured?.width ?? 200;
       const h = measured?.height ?? 150;
+
+      // Grouped nodes store position relative to their parent; use
+      // positionAbsolute (set by XYFlow internally) when available.
+      // Fall back to walking the parent chain when positionAbsolute is absent.
+      const nodeExt = node as typeof node & {
+        positionAbsolute?: { x: number; y: number };
+        parentId?: string;
+      };
+      let absolutePosition: { x: number; y: number } =
+        nodeExt.positionAbsolute ?? { ...node.position };
+
+      if (!nodeExt.positionAbsolute && nodeExt.parentId) {
+        let parentId: string | undefined = nodeExt.parentId;
+        while (parentId) {
+          const parentNode = rfInstance.current.getNode(parentId) as
+            | (typeof node & { parentId?: string })
+            | undefined;
+          if (!parentNode) break;
+          absolutePosition = {
+            x: absolutePosition.x + parentNode.position.x,
+            y: absolutePosition.y + parentNode.position.y,
+          };
+          parentId = parentNode.parentId;
+        }
+      }
+
       rfInstance.current.setCenter(
-        node.position.x + w / 2,
-        node.position.y + h / 2,
+        absolutePosition.x + w / 2,
+        absolutePosition.y + h / 2,
         { duration: 300 },
       );
     },


### PR DESCRIPTION
Implements all five requirements from F-005-keyboard-navigation.md:

R1 – SHIFT+RIGHT: navigate to the primary downstream node (first outgoing
  edge). Deselects current node, selects and pans to the next node.

R2 – SHIFT+LEFT: navigate to the primary upstream node (first incoming
  edge). Same selection/pan behaviour.

R3 – Wrap-around: at the downstream terminus SHIFT+RIGHT jumps to the
  chain start; at the upstream terminus SHIFT+LEFT jumps to the chain end.
  Cycle guard prevents infinite traversal on cyclic graphs.

R4 – SHIFT+TAB: with a node selected, jumps focus to its first output
  edge (highlighted via XYFlow edge selection). No-op if the node has no
  outgoing edges. ESC returns selection to the source node.

R5 – SPACE on focused edge: opens a filterable quick-insert dropdown
  positioned near the source node's output handle. Selecting a node type
  splices it into the graph (source→new→target), removes the old edge,
  and selects the new node. ESC cancels.

New files:
  src/hooks/useGraphNavigation.ts        – graph traversal hook
  src/components/panels/QuickInsertDropdown.tsx – quick-insert popup

Modified:
  src/components/panels/EditorPanel.tsx  – wires up all shortcuts

Focus boundary: SHIFT+arrows/TAB/SPACE only fire when no INPUT, TEXTAREA,
SELECT, or contentEditable element is focused, keeping F-001 keyboard
navigation (Tab/Enter inside expression inputs) fully independent.

https://claude.ai/code/session_016GfdT6eErbQZeP4pavJpFm