### PR TITLE
feat(F-006): replace text badges in tab bar with Lucide icons

### DIFF
--- a/features/F-006-tab-type-indicators.md
+++ b/features/F-006-tab-type-indicators.md
@@ -1,6 +1,6 @@
 # F-006: Editor Tab Type Indicators
 
-**Status**: Draft — Ready for Architectural Review
+**Status**: Implemented
 **Source Plans**: `plans/icons-in-tab-editor.md`
 **Dependencies**: None
 **Estimated Complexity**: S
@@ -22,12 +22,14 @@ A glanceable type indicator lets users orient instantly.
 Each tab in the editor tab bar displays a Lucide icon before the tab name, indicating the tab's type.
 
 **Acceptance Criteria:**
-- [ ] Main project tab: `box` icon (Lucide)
-- [ ] Loop tabs: `refresh-cw` icon (Lucide)
-- [ ] Module tabs: `puzzle` icon (Lucide)
-- [ ] Icon is rendered inline before the tab name: `<Icon /> <TabName>`
-- [ ] Icons are small, consistent with the design guidelines (minimal, clean)
-- [ ] Icon color follows tab type semantic colors from the style guide (if applicable — e.g., purple for modules)
+- [x] Main project tab: `box` icon (Lucide) — blue-400
+- [x] Loop tabs: `refresh-cw` icon (Lucide) — amber-400
+- [x] Module tabs: `puzzle` icon (Lucide) — purple-400
+- [x] Sketch tabs: `pen-tool` icon (Lucide) — pink-400
+- [x] Parameters tab: `settings` icon (Lucide) replacing gear emoji
+- [x] Icon is rendered inline before the tab name: `<Icon /> <TabName>`
+- [x] Icons are small (10px), consistent with the design guidelines (minimal, clean)
+- [x] Icon color follows tab type semantic colors (blue/amber/purple/pink)
 
 ---
 
@@ -52,8 +54,8 @@ The README mentions a "2D sketch editor." If sketch tabs exist, they may need th
 
 ### Open Questions for Review
 
-- [ ] **Are there other tab types** beyond main, loop, and module that need icons? (e.g., sketch tabs) - Sketch tabs, Parameter Tab (currently has a gear emoji)
-- [ ] **Icon color**: Should icons be monochrome (gray-400) or match semantic tab type colors (blue for main, purple for modules, etc.)? semantic tab colors.
+- [x] **Are there other tab types** beyond main, loop, and module that need icons? — Yes: sketch (`pen-tool`, pink-400) and Parameters (`settings`, inherits amber color). Both implemented.
+- [x] **Icon color**: Semantic tab type colors — blue for main, amber for loop, purple for modules, pink for sketch.
 
 ---
 

--- a/src/components/panels/TabBar.tsx
+++ b/src/components/panels/TabBar.tsx
@@ -1,5 +1,21 @@
 import { useState } from 'react'
-import { useEditorStore } from '@/store/editorStore'
+import { Box, RefreshCw, Puzzle, PenTool, Settings } from 'lucide-react'
+import { useEditorStore, type TabType } from '@/store/editorStore'
+
+function TabTypeIcon({ tabType }: { tabType: TabType }) {
+  switch (tabType) {
+    case 'main':
+      return <Box size={10} className="text-blue-400 shrink-0" />
+    case 'loop':
+      return <RefreshCw size={10} className="text-amber-400 shrink-0" />
+    case 'module':
+      return <Puzzle size={10} className="text-purple-400 shrink-0" />
+    case 'sketch':
+      return <PenTool size={10} className="text-pink-400 shrink-0" />
+    default:
+      return null
+  }
+}
 
 export function TabBar() {
   const { tabs, activeTabId, addTab, removeTab, renameTab, setActiveTab } = useEditorStore()
@@ -38,22 +54,8 @@ export function TabBar() {
           }}
           onDoubleClick={() => startRename(tab.id, tab.label)}
         >
-          {/* Tab type badge */}
-          {tab.tabType === 'module' && (
-            <span className="text-[8px] bg-purple-600/50 text-purple-300 rounded px-1 py-0 font-bold uppercase">
-              mod
-            </span>
-          )}
-          {tab.tabType === 'sketch' && (
-            <span className="text-[8px] bg-pink-600/50 text-pink-300 rounded px-1 py-0 font-bold uppercase">
-              skt
-            </span>
-          )}
-          {tab.tabType === 'loop' && (
-            <span className="text-[8px] bg-amber-700/60 text-amber-300 rounded px-1 py-0 font-bold uppercase">
-              lp
-            </span>
-          )}
+          {/* Tab type icon (F-006) */}
+          <TabTypeIcon tabType={tab.tabType} />
 
           {/* Tab name (editable) */}
           {editing === tab.id ? (
@@ -134,7 +136,7 @@ export function TabBar() {
         onClick={() => setShowParametersPanel(!showParametersPanel)}
         title="Global parameters table"
       >
-        <span className="text-[9px] opacity-70">⚙</span>
+        <Settings size={10} className="shrink-0 opacity-70" />
         Parameters
       </button>
     </div>


### PR DESCRIPTION
Implements F-006 (Tab Type Indicators) from features/F-006-tab-type-indicators.md.

- Adds TabTypeIcon helper mapping tabType → Lucide icon with semantic color:
  main → Box (blue-400), loop → RefreshCw (amber-400),
  module → Puzzle (purple-400), sketch → PenTool (pink-400)
- Replaces the "mod"/"skt"/"lp" text badge spans with the icon component
- Replaces the ⚙ gear emoji in the Parameters tab with Settings icon
- Updates F-006 feature file: status → Implemented, all ACs checked

https://claude.ai/code/session_01GMiqTc9g7nfTBqfuWXbLJD