### PR TITLE
Add 15 BOSL2 Tier 1 3D shape primitive node components

### DIFF
--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from 'vitest'
 import type { Node } from '@xyflow/react'
 import type { CodegenContext } from '@/types/nodePack'
 
+import {
+  bosl2Shapes3dPack,
+  bosl2Shapes2dPack,
+  bosl2TransformsPack,
+  bosl2DistributorsPack,
+  bosl2RoundingPack,
+  bosl2MechanicalPack,
+  bosl2AttachmentsPack,
+} from '../index'
+
 import { shapes3dCodegen } from '../codegen/shapes3dCodegen'
 import { shapes2dCodegen } from '../codegen/shapes2dCodegen'
 import { transformsCodegen } from '../codegen/transformsCodegen'
@@ -1063,6 +1073,59 @@ describe('BOSL2 Codegen Handlers', () => {
 
     it('returns null for empty node array', () => {
       expect(bosl2Preamble([])).toBeNull()
+    })
+  })
+
+  // ─── Regression: preamble must be on exactly one pack ────────────────────
+  // The codegen pipeline calls pack.preamble(nodes) for every registered pack.
+  // If multiple packs share the same preamble function the includes are emitted
+  // once per pack, producing duplicate include lines in the output.
+
+  describe('Pack registry — preamble ownership', () => {
+    const allPacks = [
+      bosl2Shapes3dPack,
+      bosl2Shapes2dPack,
+      bosl2TransformsPack,
+      bosl2DistributorsPack,
+      bosl2RoundingPack,
+      bosl2MechanicalPack,
+      bosl2AttachmentsPack,
+    ]
+
+    it('exactly one BOSL2 pack owns a preamble function', () => {
+      const packsWithPreamble = allPacks.filter((p) => p.preamble != null)
+      expect(packsWithPreamble).toHaveLength(1)
+    })
+
+    it('simulated pipeline does not emit duplicate std.scad include', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_cuboid', position: { x: 0, y: 0 }, data: {} },
+      ]
+      // Simulate what codegen/index.ts does: call preamble on every pack
+      let combined = ''
+      for (const pack of allPacks) {
+        if (pack.preamble) {
+          const result = pack.preamble(nodes)
+          if (result) combined += result
+        }
+      }
+      const count = (combined.match(/include <BOSL2\/std\.scad>/g) || []).length
+      expect(count).toBe(1)
+    })
+
+    it('simulated pipeline does not emit duplicate gears include', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_spur_gear', position: { x: 0, y: 0 }, data: {} },
+      ]
+      let combined = ''
+      for (const pack of allPacks) {
+        if (pack.preamble) {
+          const result = pack.preamble(nodes)
+          if (result) combined += result
+        }
+      }
+      const count = (combined.match(/include <BOSL2\/gears\.scad>/g) || []).length
+      expect(count).toBe(1)
     })
   })
 })

--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -1,0 +1,1068 @@
+import { describe, it, expect } from 'vitest'
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+import { shapes3dCodegen } from '../codegen/shapes3dCodegen'
+import { shapes2dCodegen } from '../codegen/shapes2dCodegen'
+import { transformsCodegen } from '../codegen/transformsCodegen'
+import { distributorsCodegen } from '../codegen/distributorsCodegen'
+import { roundingCodegen } from '../codegen/roundingCodegen'
+import { mechanicalCodegen } from '../codegen/mechanicalCodegen'
+import { attachmentsCodegen } from '../codegen/attachmentsCodegen'
+import { bosl2Preamble } from '../preamble'
+
+import { SHAPES3D_PALETTE } from '../palette/shapes3dPalette'
+import { SHAPES2D_PALETTE } from '../palette/shapes2dPalette'
+import { TRANSFORMS_PALETTE, DISTRIBUTORS_PALETTE } from '../palette/transformsPalette'
+import { ROUNDING_PALETTE } from '../palette/roundingPalette'
+import { MECHANICAL_PALETTE } from '../palette/mechanicalPalette'
+import { ATTACHMENTS_PALETTE } from '../palette/attachmentsPalette'
+
+// ─── Mock CodegenContext ──────────────────────────────────────────────────────
+
+const mockCtx: CodegenContext = {
+  pad: '  ',
+  num: (v) => (typeof v === 'number' ? v : parseFloat(String(v)) || 0),
+  expr: (v) => (typeof v === 'number' ? String(v) : String(v ?? '0').trim() || '0'),
+  bool: (v) => (v ? 'true' : 'false'),
+  escapeString: (v) =>
+    String(v ?? '')
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"'),
+  sanitizeIdentifier: (raw, fallback = 'value') => {
+    const s = String(raw ?? '').replace(/[^a-zA-Z0-9_]/g, '_')
+    return s || fallback
+  },
+  resolveValueInput: (_index, fallback) => fallback,
+  getAllChildren: () => '    // No children connected\n',
+  getChild: () => '',
+  hasChild: () => false,
+  emitTransform: (header) => `  ${header} {\n    // No children connected\n  }\n`,
+}
+
+// ─── Helper: create a mock Node from palette defaults ─────────────────────────
+
+function mockNode(type: string, data: Record<string, unknown>): Node {
+  return {
+    id: `test-${type}`,
+    type,
+    position: { x: 0, y: 0 },
+    data,
+  }
+}
+
+// ─── Collect all handlers and palette items ───────────────────────────────────
+
+const allHandlers: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  ...shapes3dCodegen,
+  ...shapes2dCodegen,
+  ...transformsCodegen,
+  ...distributorsCodegen,
+  ...roundingCodegen,
+  ...mechanicalCodegen,
+  ...attachmentsCodegen,
+}
+
+const allPaletteItems = [
+  ...SHAPES3D_PALETTE,
+  ...SHAPES2D_PALETTE,
+  ...TRANSFORMS_PALETTE,
+  ...DISTRIBUTORS_PALETTE,
+  ...ROUNDING_PALETTE,
+  ...MECHANICAL_PALETTE,
+  ...ATTACHMENTS_PALETTE,
+]
+
+const paletteByType = Object.fromEntries(allPaletteItems.map((p) => [p.type, p]))
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('BOSL2 Codegen Handlers', () => {
+  // ─── Smoke test: every handler produces non-empty output with defaults ──────
+
+  describe('All handlers produce valid output with default data', () => {
+    for (const [type, handler] of Object.entries(allHandlers)) {
+      it(`${type} produces non-empty output`, () => {
+        const palette = paletteByType[type]
+        expect(palette).toBeDefined()
+        const node = mockNode(type, { ...palette.defaultData })
+        const result = handler(node, mockCtx)
+        expect(result).toBeTruthy()
+        expect(result.length).toBeGreaterThan(0)
+        expect(result.trim()).not.toBe('')
+      })
+    }
+  })
+
+  // ─── Verify handler ↔ palette coverage ──────────────────────────────────────
+
+  describe('Handler–palette coverage', () => {
+    it('every palette item has a matching codegen handler', () => {
+      for (const item of allPaletteItems) {
+        expect(allHandlers[item.type]).toBeDefined()
+      }
+    })
+
+    it('every codegen handler has a matching palette item', () => {
+      for (const type of Object.keys(allHandlers)) {
+        expect(paletteByType[type]).toBeDefined()
+      }
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 1: 3D Shapes
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 1 – 3D Shapes', () => {
+    it('cuboid – default output', () => {
+      const node = mockNode('bosl2_cuboid', { x: 10, y: 10, z: 10, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_cuboid(node, mockCtx)
+      expect(result).toBe('  cuboid([10, 10, 10]);\n')
+    })
+
+    it('cuboid – with rounding and chamfer', () => {
+      const node = mockNode('bosl2_cuboid', { x: 20, y: 15, z: 5, rounding: 2, chamfer: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_cuboid(node, mockCtx)
+      expect(result).toBe('  cuboid([20, 15, 5], rounding = 2, chamfer = 1);\n')
+    })
+
+    it('cuboid – with non-default anchor/spin/orient', () => {
+      const node = mockNode('bosl2_cuboid', { x: 10, y: 10, z: 10, rounding: 0, chamfer: 0, anchor: 'BOT', spin: 45, orient: 'FWD' })
+      const result = shapes3dCodegen.bosl2_cuboid(node, mockCtx)
+      expect(result).toBe('  cuboid([10, 10, 10], anchor = BOT, spin = 45, orient = FWD);\n')
+    })
+
+    it('cyl – default output (equal r1/r2 uses r)', () => {
+      const node = mockNode('bosl2_cyl', { h: 10, r: 5, r1: 5, r2: 5, chamfer: 0, rounding: 0, circum: false, fn: 32, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_cyl(node, mockCtx)
+      expect(result).toBe('  cyl(h = 10, r = 5);\n')
+    })
+
+    it('cyl – different r1/r2 produces cone', () => {
+      const node = mockNode('bosl2_cyl', { h: 20, r: 5, r1: 10, r2: 3, chamfer: 0, rounding: 0, circum: false, fn: 32, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_cyl(node, mockCtx)
+      expect(result).toBe('  cyl(h = 20, r1 = 10, r2 = 3);\n')
+    })
+
+    it('cyl – with chamfer, rounding, circum, fn', () => {
+      const node = mockNode('bosl2_cyl', { h: 10, r: 5, r1: 5, r2: 5, chamfer: 1, rounding: 2, circum: true, fn: 64, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_cyl(node, mockCtx)
+      expect(result).toBe('  cyl(h = 10, r = 5, chamfer = 1, rounding = 2, circum = true, $fn = 64);\n')
+    })
+
+    it('spheroid – default', () => {
+      const node = mockNode('bosl2_spheroid', { r: 10, style: 'aligned', circum: false, fn: 32, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_spheroid(node, mockCtx)
+      expect(result).toBe('  spheroid(r = 10);\n')
+    })
+
+    it('spheroid – with style and circum', () => {
+      const node = mockNode('bosl2_spheroid', { r: 15, style: 'icosa', circum: true, fn: 64, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_spheroid(node, mockCtx)
+      expect(result).toBe('  spheroid(r = 15, style = "icosa", circum = true, $fn = 64);\n')
+    })
+
+    it('torus – default', () => {
+      const node = mockNode('bosl2_torus', { r_maj: 20, r_min: 5, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_torus(node, mockCtx)
+      expect(result).toBe('  torus(r_maj = 20, r_min = 5);\n')
+    })
+
+    it('tube – default', () => {
+      const node = mockNode('bosl2_tube', { h: 20, or: 10, ir: 8, wall: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_tube(node, mockCtx)
+      expect(result).toBe('  tube(h = 20, or = 10, ir = 8);\n')
+    })
+
+    it('tube – with wall', () => {
+      const node = mockNode('bosl2_tube', { h: 20, or: 10, ir: 0, wall: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_tube(node, mockCtx)
+      expect(result).toBe('  tube(h = 20, or = 10, wall = 2);\n')
+    })
+
+    it('prismoid – default', () => {
+      const node = mockNode('bosl2_prismoid', { size1_x: 20, size1_y: 20, size2_x: 10, size2_y: 10, h: 15, shift_x: 0, shift_y: 0, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_prismoid(node, mockCtx)
+      expect(result).toBe('  prismoid([20, 20], [10, 10], h = 15);\n')
+    })
+
+    it('prismoid – with shift and rounding', () => {
+      const node = mockNode('bosl2_prismoid', { size1_x: 20, size1_y: 20, size2_x: 10, size2_y: 10, h: 15, shift_x: 5, shift_y: 3, rounding: 2, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_prismoid(node, mockCtx)
+      expect(result).toBe('  prismoid([20, 20], [10, 10], h = 15, shift = [5, 3], rounding = 2);\n')
+    })
+
+    it('wedge – default', () => {
+      const node = mockNode('bosl2_wedge', { x: 10, y: 10, z: 10, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_wedge(node, mockCtx)
+      expect(result).toBe('  wedge([10, 10, 10]);\n')
+    })
+
+    it('pie_slice – default', () => {
+      const node = mockNode('bosl2_pie_slice', { h: 10, r: 10, ang: 90, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_pie_slice(node, mockCtx)
+      expect(result).toBe('  pie_slice(h = 10, r = 10, ang = 90);\n')
+    })
+
+    it('teardrop – default', () => {
+      const node = mockNode('bosl2_teardrop', { h: 10, r: 5, ang: 45, cap_h: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_teardrop(node, mockCtx)
+      expect(result).toBe('  teardrop(h = 10, r = 5);\n')
+    })
+
+    it('teardrop – with custom angle and cap', () => {
+      const node = mockNode('bosl2_teardrop', { h: 10, r: 5, ang: 60, cap_h: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_teardrop(node, mockCtx)
+      expect(result).toBe('  teardrop(h = 10, r = 5, ang = 60, cap_h = 3);\n')
+    })
+
+    it('onion – default', () => {
+      const node = mockNode('bosl2_onion', { r: 10, ang: 45, cap_h: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_onion(node, mockCtx)
+      expect(result).toBe('  onion(r = 10);\n')
+    })
+
+    it('rect_tube – default', () => {
+      const node = mockNode('bosl2_rect_tube', { h: 20, size_x: 20, size_y: 20, isize_x: 16, isize_y: 16, wall: 0, rounding: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_rect_tube(node, mockCtx)
+      expect(result).toBe('  rect_tube(h = 20, size = [20, 20], isize = [16, 16]);\n')
+    })
+
+    it('octahedron – default', () => {
+      const node = mockNode('bosl2_octahedron', { size: 20, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_octahedron(node, mockCtx)
+      expect(result).toBe('  octahedron(size = 20);\n')
+    })
+
+    it('regular_prism – default', () => {
+      const node = mockNode('bosl2_regular_prism', { n: 6, h: 10, r: 5, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_regular_prism(node, mockCtx)
+      expect(result).toBe('  regular_prism(n = 6, h = 10, r = 5);\n')
+    })
+
+    it('text3d – default', () => {
+      const node = mockNode('bosl2_text3d', { text: 'Hello', h: 2, size: 10, font: 'Liberation Sans', anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_text3d(node, mockCtx)
+      expect(result).toBe('  text3d("Hello", h = 2, size = 10, font = "Liberation Sans");\n')
+    })
+
+    it('fillet – default', () => {
+      const node = mockNode('bosl2_fillet', { h: 10, r: 3, ang: 90, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_fillet(node, mockCtx)
+      expect(result).toBe('  fillet(h = 10, r = 3);\n')
+    })
+
+    it('fillet – with custom angle', () => {
+      const node = mockNode('bosl2_fillet', { h: 10, r: 3, ang: 45, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = shapes3dCodegen.bosl2_fillet(node, mockCtx)
+      expect(result).toBe('  fillet(h = 10, r = 3, ang = 45);\n')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 2: 2D Shapes
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 2 – 2D Shapes', () => {
+    it('rect – default', () => {
+      const node = mockNode('bosl2_rect', { x: 20, y: 10, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_rect(node, mockCtx)
+      expect(result).toBe('  rect([20, 10]);\n')
+    })
+
+    it('rect – with rounding', () => {
+      const node = mockNode('bosl2_rect', { x: 20, y: 10, rounding: 3, chamfer: 0, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_rect(node, mockCtx)
+      expect(result).toBe('  rect([20, 10], rounding = 3);\n')
+    })
+
+    it('ellipse – default', () => {
+      const node = mockNode('bosl2_ellipse', { rx: 10, ry: 5, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_ellipse(node, mockCtx)
+      expect(result).toBe('  ellipse(r = [10, 5]);\n')
+    })
+
+    it('regular_ngon – default', () => {
+      const node = mockNode('bosl2_regular_ngon', { n: 6, r: 10, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_regular_ngon(node, mockCtx)
+      expect(result).toBe('  regular_ngon(n = 6, r = 10);\n')
+    })
+
+    it('pentagon – default', () => {
+      const node = mockNode('bosl2_pentagon', { r: 10, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_pentagon(node, mockCtx)
+      expect(result).toBe('  pentagon(r = 10);\n')
+    })
+
+    it('hexagon – default', () => {
+      const node = mockNode('bosl2_hexagon', { r: 10, rounding: 0, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_hexagon(node, mockCtx)
+      expect(result).toBe('  hexagon(r = 10);\n')
+    })
+
+    it('hexagon – with rounding', () => {
+      const node = mockNode('bosl2_hexagon', { r: 10, rounding: 2, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_hexagon(node, mockCtx)
+      expect(result).toBe('  hexagon(r = 10, rounding = 2);\n')
+    })
+
+    it('octagon – default', () => {
+      const node = mockNode('bosl2_octagon', { r: 10, rounding: 0, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_octagon(node, mockCtx)
+      expect(result).toBe('  octagon(r = 10);\n')
+    })
+
+    it('star – default', () => {
+      const node = mockNode('bosl2_star', { n: 5, r: 10, ir: 5, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_star(node, mockCtx)
+      expect(result).toBe('  star(n = 5, r = 10, ir = 5);\n')
+    })
+
+    it('trapezoid – default', () => {
+      const node = mockNode('bosl2_trapezoid', { h: 10, w1: 20, w2: 10, rounding: 0, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_trapezoid(node, mockCtx)
+      expect(result).toBe('  trapezoid(h = 10, w1 = 20, w2 = 10);\n')
+    })
+
+    it('right_triangle – default', () => {
+      const node = mockNode('bosl2_right_triangle', { x: 10, y: 10, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_right_triangle(node, mockCtx)
+      expect(result).toBe('  right_triangle([10, 10]);\n')
+    })
+
+    it('teardrop2d – default', () => {
+      const node = mockNode('bosl2_teardrop2d', { r: 10, ang: 45, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_teardrop2d(node, mockCtx)
+      expect(result).toBe('  teardrop2d(r = 10);\n')
+    })
+
+    it('teardrop2d – with custom angle', () => {
+      const node = mockNode('bosl2_teardrop2d', { r: 10, ang: 60, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_teardrop2d(node, mockCtx)
+      expect(result).toBe('  teardrop2d(r = 10, ang = 60);\n')
+    })
+
+    it('squircle – default', () => {
+      const node = mockNode('bosl2_squircle', { x: 20, y: 20, squareness: 0.5, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_squircle(node, mockCtx)
+      expect(result).toBe('  squircle([20, 20]);\n')
+    })
+
+    it('squircle – custom squareness', () => {
+      const node = mockNode('bosl2_squircle', { x: 20, y: 20, squareness: 0.8, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_squircle(node, mockCtx)
+      expect(result).toBe('  squircle([20, 20], squareness = 0.8);\n')
+    })
+
+    it('ring – default', () => {
+      const node = mockNode('bosl2_ring', { n: 36, r1: 10, r2: 8, anchor: 'CENTER', spin: 0 })
+      const result = shapes2dCodegen.bosl2_ring(node, mockCtx)
+      expect(result).toBe('  ring(n = 36, r1 = 10, r2 = 8);\n')
+    })
+
+    it('2D shapes respect spin parameter', () => {
+      const node = mockNode('bosl2_pentagon', { r: 10, anchor: 'CENTER', spin: 30 })
+      const result = shapes2dCodegen.bosl2_pentagon(node, mockCtx)
+      expect(result).toBe('  pentagon(r = 10, spin = 30);\n')
+    })
+
+    it('2D shapes respect non-default anchor', () => {
+      const node = mockNode('bosl2_rect', { x: 20, y: 10, rounding: 0, chamfer: 0, anchor: 'LEFT', spin: 0 })
+      const result = shapes2dCodegen.bosl2_rect(node, mockCtx)
+      expect(result).toBe('  rect([20, 10], anchor = LEFT);\n')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 3: Transforms
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 3 – Transforms', () => {
+    it('move – exact output', () => {
+      const node = mockNode('bosl2_move', { x: 10, y: 20, z: 30 })
+      const result = transformsCodegen.bosl2_move(node, mockCtx)
+      expect(result).toBe('  move([10, 20, 30]) {\n    // No children connected\n  }\n')
+    })
+
+    it('left – default', () => {
+      const node = mockNode('bosl2_left', { d: 10 })
+      const result = transformsCodegen.bosl2_left(node, mockCtx)
+      expect(result).toContain('left(10)')
+    })
+
+    it('right – default', () => {
+      const node = mockNode('bosl2_right', { d: 10 })
+      const result = transformsCodegen.bosl2_right(node, mockCtx)
+      expect(result).toContain('right(10)')
+    })
+
+    it('fwd – default', () => {
+      const node = mockNode('bosl2_fwd', { d: 10 })
+      const result = transformsCodegen.bosl2_fwd(node, mockCtx)
+      expect(result).toContain('fwd(10)')
+    })
+
+    it('back – default', () => {
+      const node = mockNode('bosl2_back', { d: 10 })
+      const result = transformsCodegen.bosl2_back(node, mockCtx)
+      expect(result).toContain('back(10)')
+    })
+
+    it('up – default', () => {
+      const node = mockNode('bosl2_up', { d: 10 })
+      const result = transformsCodegen.bosl2_up(node, mockCtx)
+      expect(result).toContain('up(10)')
+    })
+
+    it('down – default', () => {
+      const node = mockNode('bosl2_down', { d: 10 })
+      const result = transformsCodegen.bosl2_down(node, mockCtx)
+      expect(result).toContain('down(10)')
+    })
+
+    it('rot – default (no axis = simple angle)', () => {
+      const node = mockNode('bosl2_rot', { a: 0, vx: 0, vy: 0, vz: 0 })
+      const result = transformsCodegen.bosl2_rot(node, mockCtx)
+      expect(result).toContain('rot(0)')
+    })
+
+    it('rot – with axis vector', () => {
+      const node = mockNode('bosl2_rot', { a: 45, vx: 1, vy: 0, vz: 0 })
+      const result = transformsCodegen.bosl2_rot(node, mockCtx)
+      expect(result).toContain('rot(a = 45, v = [1, 0, 0])')
+    })
+
+    it('xrot – default', () => {
+      const node = mockNode('bosl2_xrot', { a: 0 })
+      const result = transformsCodegen.bosl2_xrot(node, mockCtx)
+      expect(result).toContain('xrot(0)')
+    })
+
+    it('yrot – default', () => {
+      const node = mockNode('bosl2_yrot', { a: 0 })
+      const result = transformsCodegen.bosl2_yrot(node, mockCtx)
+      expect(result).toContain('yrot(0)')
+    })
+
+    it('zrot – default', () => {
+      const node = mockNode('bosl2_zrot', { a: 0 })
+      const result = transformsCodegen.bosl2_zrot(node, mockCtx)
+      expect(result).toContain('zrot(0)')
+    })
+
+    it('xscale – default', () => {
+      const node = mockNode('bosl2_xscale', { factor: 1 })
+      const result = transformsCodegen.bosl2_xscale(node, mockCtx)
+      expect(result).toContain('xscale(1)')
+    })
+
+    it('yscale – default', () => {
+      const node = mockNode('bosl2_yscale', { factor: 1 })
+      const result = transformsCodegen.bosl2_yscale(node, mockCtx)
+      expect(result).toContain('yscale(1)')
+    })
+
+    it('zscale – default', () => {
+      const node = mockNode('bosl2_zscale', { factor: 1 })
+      const result = transformsCodegen.bosl2_zscale(node, mockCtx)
+      expect(result).toContain('zscale(1)')
+    })
+
+    it('xflip – default (no offset)', () => {
+      const node = mockNode('bosl2_xflip', { offset: 0 })
+      const result = transformsCodegen.bosl2_xflip(node, mockCtx)
+      expect(result).toContain('xflip()')
+    })
+
+    it('xflip – with offset', () => {
+      const node = mockNode('bosl2_xflip', { offset: 5 })
+      const result = transformsCodegen.bosl2_xflip(node, mockCtx)
+      expect(result).toContain('xflip(x = 5)')
+    })
+
+    it('yflip – default', () => {
+      const node = mockNode('bosl2_yflip', { offset: 0 })
+      const result = transformsCodegen.bosl2_yflip(node, mockCtx)
+      expect(result).toContain('yflip()')
+    })
+
+    it('yflip – with offset', () => {
+      const node = mockNode('bosl2_yflip', { offset: 5 })
+      const result = transformsCodegen.bosl2_yflip(node, mockCtx)
+      expect(result).toContain('yflip(y = 5)')
+    })
+
+    it('zflip – default', () => {
+      const node = mockNode('bosl2_zflip', { offset: 0 })
+      const result = transformsCodegen.bosl2_zflip(node, mockCtx)
+      expect(result).toContain('zflip()')
+    })
+
+    it('zflip – with offset', () => {
+      const node = mockNode('bosl2_zflip', { offset: 5 })
+      const result = transformsCodegen.bosl2_zflip(node, mockCtx)
+      expect(result).toContain('zflip(z = 5)')
+    })
+
+    it('skew – all zeros (empty params)', () => {
+      const node = mockNode('bosl2_skew', { sxy: 0, sxz: 0, syx: 0, syz: 0, szx: 0, szy: 0 })
+      const result = transformsCodegen.bosl2_skew(node, mockCtx)
+      expect(result).toContain('skew()')
+    })
+
+    it('skew – with non-zero values', () => {
+      const node = mockNode('bosl2_skew', { sxy: 0.5, sxz: 0, syx: 0, syz: 0.3, szx: 0, szy: 0 })
+      const result = transformsCodegen.bosl2_skew(node, mockCtx)
+      expect(result).toContain('skew(sxy = 0.5, syz = 0.3)')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 3: Distributors
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 3 – Distributors', () => {
+    it('xcopies – default (n=3 shown)', () => {
+      const node = mockNode('bosl2_xcopies', { spacing: 10, n: 3 })
+      const result = distributorsCodegen.bosl2_xcopies(node, mockCtx)
+      expect(result).toContain('xcopies(spacing = 10, n = 3)')
+    })
+
+    it('xcopies – n=2 is default, omitted', () => {
+      const node = mockNode('bosl2_xcopies', { spacing: 10, n: 2 })
+      const result = distributorsCodegen.bosl2_xcopies(node, mockCtx)
+      expect(result).toContain('xcopies(spacing = 10)')
+      expect(result).not.toContain('n =')
+    })
+
+    it('ycopies – default', () => {
+      const node = mockNode('bosl2_ycopies', { spacing: 10, n: 3 })
+      const result = distributorsCodegen.bosl2_ycopies(node, mockCtx)
+      expect(result).toContain('ycopies(spacing = 10, n = 3)')
+    })
+
+    it('zcopies – default', () => {
+      const node = mockNode('bosl2_zcopies', { spacing: 10, n: 3 })
+      const result = distributorsCodegen.bosl2_zcopies(node, mockCtx)
+      expect(result).toContain('zcopies(spacing = 10, n = 3)')
+    })
+
+    it('grid_copies – default', () => {
+      const node = mockNode('bosl2_grid_copies', { spacing_x: 10, spacing_y: 10, n_x: 3, n_y: 3, stagger: false })
+      const result = distributorsCodegen.bosl2_grid_copies(node, mockCtx)
+      expect(result).toContain('grid_copies(spacing = [10, 10], n = [3, 3])')
+    })
+
+    it('grid_copies – with stagger', () => {
+      const node = mockNode('bosl2_grid_copies', { spacing_x: 10, spacing_y: 10, n_x: 3, n_y: 3, stagger: true })
+      const result = distributorsCodegen.bosl2_grid_copies(node, mockCtx)
+      expect(result).toContain('stagger = true')
+    })
+
+    it('rot_copies – default', () => {
+      const node = mockNode('bosl2_rot_copies', { n: 6, sa: 0 })
+      const result = distributorsCodegen.bosl2_rot_copies(node, mockCtx)
+      expect(result).toContain('rot_copies(n = 6)')
+    })
+
+    it('rot_copies – with start angle', () => {
+      const node = mockNode('bosl2_rot_copies', { n: 6, sa: 15 })
+      const result = distributorsCodegen.bosl2_rot_copies(node, mockCtx)
+      expect(result).toContain('rot_copies(n = 6, sa = 15)')
+    })
+
+    it('arc_copies – default', () => {
+      const node = mockNode('bosl2_arc_copies', { n: 6, r: 20, sa: 0, ea: 360 })
+      const result = distributorsCodegen.bosl2_arc_copies(node, mockCtx)
+      expect(result).toContain('arc_copies(n = 6, r = 20)')
+    })
+
+    it('arc_copies – with custom angles', () => {
+      const node = mockNode('bosl2_arc_copies', { n: 4, r: 30, sa: 10, ea: 180 })
+      const result = distributorsCodegen.bosl2_arc_copies(node, mockCtx)
+      expect(result).toContain('arc_copies(n = 4, r = 30, sa = 10, ea = 180)')
+    })
+
+    it('mirror_copy – default', () => {
+      const node = mockNode('bosl2_mirror_copy', { vx: 1, vy: 0, vz: 0, offset: 0 })
+      const result = distributorsCodegen.bosl2_mirror_copy(node, mockCtx)
+      expect(result).toContain('mirror_copy([1, 0, 0])')
+    })
+
+    it('mirror_copy – with offset', () => {
+      const node = mockNode('bosl2_mirror_copy', { vx: 1, vy: 0, vz: 0, offset: 5 })
+      const result = distributorsCodegen.bosl2_mirror_copy(node, mockCtx)
+      expect(result).toContain('mirror_copy([1, 0, 0], offset = 5)')
+    })
+
+    it('path_copies – default', () => {
+      const node = mockNode('bosl2_path_copies', { path: '[]', n: 0, closed: false })
+      const result = distributorsCodegen.bosl2_path_copies(node, mockCtx)
+      expect(result).toContain('path_copies([])')
+    })
+
+    it('path_copies – with closed', () => {
+      const node = mockNode('bosl2_path_copies', { path: '[[0,0],[10,0],[10,10]]', n: 3, closed: true })
+      const result = distributorsCodegen.bosl2_path_copies(node, mockCtx)
+      expect(result).toContain('n = 3')
+      expect(result).toContain('closed = true')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 4: Rounding, Masks, Sweeps
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 4 – Rounding, Masks, Sweeps', () => {
+    it('offset_sweep – default', () => {
+      const node = mockNode('bosl2_offset_sweep', { height: 10, top_r: 1, bot_r: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_offset_sweep(node, mockCtx)
+      expect(result).toContain('offset_sweep(height = 10, top = os_circle(r = 1), bottom = os_circle(r = 1))')
+    })
+
+    it('offset_sweep – zero radii omitted', () => {
+      const node = mockNode('bosl2_offset_sweep', { height: 10, top_r: 0, bot_r: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_offset_sweep(node, mockCtx)
+      expect(result).toContain('offset_sweep(height = 10)')
+      expect(result).not.toContain('os_circle')
+    })
+
+    it('rounded_prism – default', () => {
+      const node = mockNode('bosl2_rounded_prism', { height: 10, joint_top: 1, joint_bot: 1, joint_sides: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_rounded_prism(node, mockCtx)
+      expect(result).toContain('rounded_prism(height = 10, joint_top = 1, joint_bot = 1, joint_sides = 1)')
+    })
+
+    it('skin – default', () => {
+      const node = mockNode('bosl2_skin', { slices: 10, method: 'reindex', style: 'min_edge' })
+      const result = roundingCodegen.bosl2_skin(node, mockCtx)
+      expect(result).toContain('skin(slices = 10)')
+    })
+
+    it('skin – custom method and style', () => {
+      const node = mockNode('bosl2_skin', { slices: 20, method: 'distance', style: 'convex' })
+      const result = roundingCodegen.bosl2_skin(node, mockCtx)
+      expect(result).toContain('skin(slices = 20, method = "distance", style = "convex")')
+    })
+
+    it('linear_sweep – default', () => {
+      const node = mockNode('bosl2_linear_sweep', { height: 10, twist: 0, scale: 1, slices: 0, center: false, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_linear_sweep(node, mockCtx)
+      expect(result).toContain('linear_sweep(height = 10)')
+    })
+
+    it('linear_sweep – with twist, scale, center', () => {
+      const node = mockNode('bosl2_linear_sweep', { height: 20, twist: 90, scale: 0.5, slices: 40, center: true, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_linear_sweep(node, mockCtx)
+      expect(result).toContain('twist = 90')
+      expect(result).toContain('scale = 0.5')
+      expect(result).toContain('slices = 40')
+      expect(result).toContain('center = true')
+    })
+
+    it('rotate_sweep – default (360 omitted)', () => {
+      const node = mockNode('bosl2_rotate_sweep', { angle: 360, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_rotate_sweep(node, mockCtx)
+      expect(result).toContain('rotate_sweep(')
+      expect(result).not.toContain('angle =')
+    })
+
+    it('rotate_sweep – custom angle', () => {
+      const node = mockNode('bosl2_rotate_sweep', { angle: 180, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_rotate_sweep(node, mockCtx)
+      expect(result).toContain('angle = 180')
+    })
+
+    it('path_sweep – default', () => {
+      const node = mockNode('bosl2_path_sweep', { method: 'incremental', twist: 0, closed: false, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_path_sweep(node, mockCtx)
+      expect(result).toContain('path_sweep(')
+    })
+
+    it('path_sweep – with twist and closed', () => {
+      const node = mockNode('bosl2_path_sweep', { method: 'natural', twist: 180, closed: true, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_path_sweep(node, mockCtx)
+      expect(result).toContain('method = "natural"')
+      expect(result).toContain('twist = 180')
+      expect(result).toContain('closed = true')
+    })
+
+    it('spiral_sweep – default', () => {
+      const node = mockNode('bosl2_spiral_sweep', { h: 20, r: 10, turns: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_spiral_sweep(node, mockCtx)
+      expect(result).toContain('spiral_sweep(h = 20, r = 10, turns = 3)')
+    })
+
+    it('edge_mask – default', () => {
+      const node = mockNode('bosl2_edge_mask', { edges: 'ALL', except: '' })
+      const result = roundingCodegen.bosl2_edge_mask(node, mockCtx)
+      expect(result).toContain('edge_mask(ALL)')
+    })
+
+    it('edge_mask – with except', () => {
+      const node = mockNode('bosl2_edge_mask', { edges: 'TOP', except: 'FRONT' })
+      const result = roundingCodegen.bosl2_edge_mask(node, mockCtx)
+      expect(result).toContain('edge_mask(TOP, except = FRONT)')
+    })
+
+    it('corner_mask – default', () => {
+      const node = mockNode('bosl2_corner_mask', { corners: 'ALL', except: '' })
+      const result = roundingCodegen.bosl2_corner_mask(node, mockCtx)
+      expect(result).toContain('corner_mask(ALL)')
+    })
+
+    it('rounding_edge_mask – default', () => {
+      const node = mockNode('bosl2_rounding_edge_mask', { h: 10, r: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_rounding_edge_mask(node, mockCtx)
+      expect(result).toBe('  rounding_edge_mask(h = 10, r = 2);\n')
+    })
+
+    it('chamfer_edge_mask – default', () => {
+      const node = mockNode('bosl2_chamfer_edge_mask', { h: 10, chamfer: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = roundingCodegen.bosl2_chamfer_edge_mask(node, mockCtx)
+      expect(result).toBe('  chamfer_edge_mask(h = 10, chamfer = 2);\n')
+    })
+
+    it('stroke – default', () => {
+      const node = mockNode('bosl2_stroke', { width: 1, closed: false, endcaps: 'butt' })
+      const result = roundingCodegen.bosl2_stroke(node, mockCtx)
+      expect(result).toContain('stroke(width = 1)')
+    })
+
+    it('stroke – closed with round endcaps', () => {
+      const node = mockNode('bosl2_stroke', { width: 2, closed: true, endcaps: 'round' })
+      const result = roundingCodegen.bosl2_stroke(node, mockCtx)
+      expect(result).toContain('closed = true')
+      expect(result).toContain('endcaps = "round"')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 5: Mechanical Parts
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 5 – Mechanical Parts', () => {
+    it('spur_gear – exact default output', () => {
+      const node = mockNode('bosl2_spur_gear', { mod: 2, teeth: 20, thickness: 5, pressure_angle: 20, helical: 0, shaft_diam: 5, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_spur_gear(node, mockCtx)
+      expect(result).toBe('  spur_gear(mod = 2, teeth = 20, thickness = 5, shaft_diam = 5);\n')
+    })
+
+    it('spur_gear – with custom pressure angle and helical', () => {
+      const node = mockNode('bosl2_spur_gear', { mod: 3, teeth: 16, thickness: 8, pressure_angle: 25, helical: 15, shaft_diam: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_spur_gear(node, mockCtx)
+      expect(result).toContain('pressure_angle = 25')
+      expect(result).toContain('helical = 15')
+      expect(result).not.toContain('shaft_diam')
+    })
+
+    it('rack – default', () => {
+      const node = mockNode('bosl2_rack', { mod: 2, teeth: 10, thickness: 5, pressure_angle: 20, helical: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_rack(node, mockCtx)
+      expect(result).toBe('  rack(mod = 2, teeth = 10, thickness = 5);\n')
+    })
+
+    it('bevel_gear – default', () => {
+      const node = mockNode('bosl2_bevel_gear', { mod: 2, teeth: 20, mate_teeth: 20, shaft_angle: 90, face_width: 10, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_bevel_gear(node, mockCtx)
+      expect(result).toBe('  bevel_gear(mod = 2, teeth = 20, mate_teeth = 20);\n')
+    })
+
+    it('bevel_gear – custom shaft angle and face width', () => {
+      const node = mockNode('bosl2_bevel_gear', { mod: 2, teeth: 20, mate_teeth: 15, shaft_angle: 60, face_width: 8, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_bevel_gear(node, mockCtx)
+      expect(result).toContain('shaft_angle = 60')
+      expect(result).toContain('face_width = 8')
+    })
+
+    it('worm – default', () => {
+      const node = mockNode('bosl2_worm', { mod: 2, d: 20, l: 30, starts: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_worm(node, mockCtx)
+      expect(result).toBe('  worm(mod = 2, d = 20, l = 30);\n')
+    })
+
+    it('worm – multiple starts', () => {
+      const node = mockNode('bosl2_worm', { mod: 2, d: 20, l: 30, starts: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_worm(node, mockCtx)
+      expect(result).toContain('starts = 3')
+    })
+
+    it('worm_gear – default', () => {
+      const node = mockNode('bosl2_worm_gear', { mod: 2, teeth: 30, worm_diam: 20, worm_starts: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_worm_gear(node, mockCtx)
+      expect(result).toBe('  worm_gear(mod = 2, teeth = 30, worm_diam = 20);\n')
+    })
+
+    it('threaded_rod – default', () => {
+      const node = mockNode('bosl2_threaded_rod', { d: 10, l: 30, pitch: 2, internal: false, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_threaded_rod(node, mockCtx)
+      expect(result).toBe('  threaded_rod(d = 10, l = 30, pitch = 2);\n')
+    })
+
+    it('threaded_rod – internal', () => {
+      const node = mockNode('bosl2_threaded_rod', { d: 10, l: 30, pitch: 2, internal: true, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_threaded_rod(node, mockCtx)
+      expect(result).toContain('internal = true')
+    })
+
+    it('threaded_nut – default', () => {
+      const node = mockNode('bosl2_threaded_nut', { nutwidth: 17, id: 10, h: 8, pitch: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_threaded_nut(node, mockCtx)
+      expect(result).toBe('  threaded_nut(nutwidth = 17, id = 10, h = 8, pitch = 2);\n')
+    })
+
+    it('screw – default', () => {
+      const node = mockNode('bosl2_screw', { spec: 'M3', head: 'socket', drive: 'hex', length: 12, thread_len: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_screw(node, mockCtx)
+      expect(result).toBe('  screw("M3", head = "socket", drive = "hex", length = 12);\n')
+    })
+
+    it('screw_hole – default', () => {
+      const node = mockNode('bosl2_screw_hole', { spec: 'M3', head: 'socket', length: 12, oversize: 0, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_screw_hole(node, mockCtx)
+      expect(result).toBe('  screw_hole("M3", head = "socket", length = 12);\n')
+    })
+
+    it('screw_hole – with oversize', () => {
+      const node = mockNode('bosl2_screw_hole', { spec: 'M5', head: 'socket', length: 20, oversize: 0.2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_screw_hole(node, mockCtx)
+      expect(result).toContain('oversize = 0.2')
+    })
+
+    it('nut – default', () => {
+      const node = mockNode('bosl2_nut', { spec: 'M3', shape: 'hex', thickness: 2.4, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_nut(node, mockCtx)
+      expect(result).toBe('  nut("M3", thickness = 2.4);\n')
+    })
+
+    it('nut – square shape', () => {
+      const node = mockNode('bosl2_nut', { spec: 'M3', shape: 'square', thickness: 2.4, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_nut(node, mockCtx)
+      expect(result).toContain('shape = "square"')
+    })
+
+    it('dovetail – default', () => {
+      const node = mockNode('bosl2_dovetail', { gender: 'male', width: 10, height: 5, slope: 6, slide: 20, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_dovetail(node, mockCtx)
+      expect(result).toBe('  dovetail(gender = "male", width = 10, height = 5, slope = 6, slide = 20);\n')
+    })
+
+    it('snap_pin – default', () => {
+      const node = mockNode('bosl2_snap_pin', { r: 1.5, l: 10, nub_depth: 0.4, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_snap_pin(node, mockCtx)
+      expect(result).toBe('  snap_pin(r = 1.5, l = 10, nub_depth = 0.4);\n')
+    })
+
+    it('knuckle_hinge – default', () => {
+      const node = mockNode('bosl2_knuckle_hinge', { length: 30, offset: 5, segs: 4, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_knuckle_hinge(node, mockCtx)
+      expect(result).toBe('  knuckle_hinge(length = 30, offset = 5, segs = 4);\n')
+    })
+
+    it('bottle_neck – default', () => {
+      const node = mockNode('bosl2_bottle_neck', { wall: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_bottle_neck(node, mockCtx)
+      expect(result).toBe('  generic_bottle_neck(wall = 2);\n')
+    })
+
+    it('bottle_cap – default', () => {
+      const node = mockNode('bosl2_bottle_cap', { wall: 2, texture: 'pointed', anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_bottle_cap(node, mockCtx)
+      expect(result).toBe('  generic_bottle_cap(wall = 2, texture = "pointed");\n')
+    })
+
+    it('bottle_cap – no texture', () => {
+      const node = mockNode('bosl2_bottle_cap', { wall: 2, texture: '', anchor: 'CENTER', spin: 0, orient: 'UP' })
+      const result = mechanicalCodegen.bosl2_bottle_cap(node, mockCtx)
+      expect(result).toBe('  generic_bottle_cap(wall = 2);\n')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Tier 6: Attachments & Advanced
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Tier 6 – Attachments & Advanced', () => {
+    it('diff – default', () => {
+      const node = mockNode('bosl2_diff', { remove: 'remove', keep: '' })
+      const result = attachmentsCodegen.bosl2_diff(node, mockCtx)
+      expect(result).toContain('diff("remove")')
+    })
+
+    it('diff – with keep', () => {
+      const node = mockNode('bosl2_diff', { remove: 'remove', keep: 'keep' })
+      const result = attachmentsCodegen.bosl2_diff(node, mockCtx)
+      expect(result).toContain('diff("remove", keep = "keep")')
+    })
+
+    it('intersect – default', () => {
+      const node = mockNode('bosl2_intersect', { intersect: 'intersect', keep: '' })
+      const result = attachmentsCodegen.bosl2_intersect(node, mockCtx)
+      expect(result).toContain('intersect("intersect")')
+    })
+
+    it('intersect – with keep', () => {
+      const node = mockNode('bosl2_intersect', { intersect: 'intersect', keep: 'keep' })
+      const result = attachmentsCodegen.bosl2_intersect(node, mockCtx)
+      expect(result).toContain('intersect("intersect", keep = "keep")')
+    })
+
+    it('position – default', () => {
+      const node = mockNode('bosl2_position', { at: 'TOP' })
+      const result = attachmentsCodegen.bosl2_position(node, mockCtx)
+      expect(result).toContain('position(TOP)')
+    })
+
+    it('attach – default', () => {
+      const node = mockNode('bosl2_attach', { parent: 'TOP', child: 'BOT', overlap: 0 })
+      const result = attachmentsCodegen.bosl2_attach(node, mockCtx)
+      expect(result).toContain('attach(TOP, BOT)')
+    })
+
+    it('attach – with overlap', () => {
+      const node = mockNode('bosl2_attach', { parent: 'TOP', child: 'BOT', overlap: 0.5 })
+      const result = attachmentsCodegen.bosl2_attach(node, mockCtx)
+      expect(result).toContain('attach(TOP, BOT, overlap = 0.5)')
+    })
+
+    it('tag – default', () => {
+      const node = mockNode('bosl2_tag', { tag: 'remove' })
+      const result = attachmentsCodegen.bosl2_tag(node, mockCtx)
+      expect(result).toContain('tag("remove")')
+    })
+
+    it('recolor – default', () => {
+      const node = mockNode('bosl2_recolor', { c: 'red' })
+      const result = attachmentsCodegen.bosl2_recolor(node, mockCtx)
+      expect(result).toContain('recolor("red")')
+    })
+
+    it('half_of – default', () => {
+      const node = mockNode('bosl2_half_of', { vx: 0, vy: 0, vz: 1, cpx: 0, cpy: 0, cpz: 0 })
+      const result = attachmentsCodegen.bosl2_half_of(node, mockCtx)
+      expect(result).toContain('half_of([0, 0, 1])')
+      expect(result).not.toContain('cp =')
+    })
+
+    it('half_of – with center point', () => {
+      const node = mockNode('bosl2_half_of', { vx: 0, vy: 0, vz: 1, cpx: 5, cpy: 0, cpz: 0 })
+      const result = attachmentsCodegen.bosl2_half_of(node, mockCtx)
+      expect(result).toContain('cp = [5, 0, 0]')
+    })
+
+    it('partition – default', () => {
+      const node = mockNode('bosl2_partition', { x: 100, y: 100, z: 100, spread: 10, cutpath: 'jigsaw' })
+      const result = attachmentsCodegen.bosl2_partition(node, mockCtx)
+      expect(result).toContain('partition(size = [100, 100, 100], spread = 10, cutpath = "jigsaw")')
+    })
+
+    it('partition – no spread, no cutpath', () => {
+      const node = mockNode('bosl2_partition', { x: 100, y: 100, z: 100, spread: 0, cutpath: '' })
+      const result = attachmentsCodegen.bosl2_partition(node, mockCtx)
+      expect(result).toContain('partition(size = [100, 100, 100])')
+      expect(result).not.toContain('spread')
+      expect(result).not.toContain('cutpath')
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // Preamble
+  // ═══════════════════════════════════════════════════════════════════════════════
+
+  describe('Preamble', () => {
+    it('returns null when no BOSL2 nodes present', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'cube', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', type: 'sphere', position: { x: 0, y: 0 }, data: {} },
+      ]
+      expect(bosl2Preamble(nodes)).toBeNull()
+    })
+
+    it('returns base include for any BOSL2 node', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_cuboid', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/std.scad>')
+    })
+
+    it('adds gears include for spur_gear', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_spur_gear', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/std.scad>')
+      expect(result).toContain('include <BOSL2/gears.scad>')
+    })
+
+    it('adds threading include for threaded_rod', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_threaded_rod', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/threading.scad>')
+    })
+
+    it('adds screws include for screw node', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_screw', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/screws.scad>')
+    })
+
+    it('adds joiners include for dovetail', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_dovetail', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/joiners.scad>')
+    })
+
+    it('adds hinges include for knuckle_hinge', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_knuckle_hinge', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/hinges.scad>')
+    })
+
+    it('adds bottlecaps include for bottle_neck', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_bottle_neck', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)
+      expect(result).toContain('include <BOSL2/bottlecaps.scad>')
+    })
+
+    it('deduplicates extra includes', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_spur_gear', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', type: 'bosl2_rack', position: { x: 0, y: 0 }, data: {} },
+        { id: '3', type: 'bosl2_bevel_gear', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)!
+      const gearsCount = (result.match(/include <BOSL2\/gears\.scad>/g) || []).length
+      expect(gearsCount).toBe(1)
+    })
+
+    it('includes multiple different extra includes', () => {
+      const nodes: Node[] = [
+        { id: '1', type: 'bosl2_spur_gear', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', type: 'bosl2_screw', position: { x: 0, y: 0 }, data: {} },
+        { id: '3', type: 'bosl2_dovetail', position: { x: 0, y: 0 }, data: {} },
+      ]
+      const result = bosl2Preamble(nodes)!
+      expect(result).toContain('include <BOSL2/gears.scad>')
+      expect(result).toContain('include <BOSL2/screws.scad>')
+      expect(result).toContain('include <BOSL2/joiners.scad>')
+    })
+
+    it('returns null for empty node array', () => {
+      expect(bosl2Preamble([])).toBeNull()
+    })
+  })
+})

--- a/src/nodepacks/bosl2/codegen/attachmentsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/attachmentsCodegen.ts
@@ -1,0 +1,69 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 6: Attachments & Advanced codegen handlers ────────────────────────
+
+export const attachmentsCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_diff: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const remove = String(d.remove ?? 'remove')
+    const keep = String(d.keep ?? '')
+    let params = `"${remove}"`
+    if (keep) params += `, keep = "${keep}"`
+    return ctx.emitTransform(`diff(${params})`)
+  },
+
+  bosl2_intersect: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const intersect = String(d.intersect ?? 'intersect')
+    const keep = String(d.keep ?? '')
+    let params = `"${intersect}"`
+    if (keep) params += `, keep = "${keep}"`
+    return ctx.emitTransform(`intersect(${params})`)
+  },
+
+  bosl2_position: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const at = String(d.at ?? 'TOP')
+    return ctx.emitTransform(`position(${at})`)
+  },
+
+  bosl2_attach: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const parent = String(d.parent ?? 'TOP')
+    const child = String(d.child ?? 'BOT')
+    let params = `${parent}, ${child}`
+    const ov = ctx.expr(d.overlap); if (ov !== '0') params += `, overlap = ${ov}`
+    return ctx.emitTransform(`attach(${params})`)
+  },
+
+  bosl2_tag: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const tag = String(d.tag ?? 'remove')
+    return ctx.emitTransform(`tag("${tag}")`)
+  },
+
+  bosl2_recolor: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const c = String(d.c ?? 'red')
+    return ctx.emitTransform(`recolor("${c}")`)
+  },
+
+  bosl2_half_of: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const v = `[${ctx.expr(d.vx)}, ${ctx.expr(d.vy)}, ${ctx.expr(d.vz)}]`
+    const cp = `[${ctx.expr(d.cpx)}, ${ctx.expr(d.cpy)}, ${ctx.expr(d.cpz)}]`
+    let params = `${v}`
+    if (cp !== '[0, 0, 0]') params += `, cp = ${cp}`
+    return ctx.emitTransform(`half_of(${params})`)
+  },
+
+  bosl2_partition: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const size = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    let params = `size = ${size}`
+    const sp = ctx.expr(d.spread); if (sp !== '0') params += `, spread = ${sp}`
+    const cp = String(d.cutpath ?? ''); if (cp) params += `, cutpath = "${cp}"`
+    return ctx.emitTransform(`partition(${params})`)
+  },
+}

--- a/src/nodepacks/bosl2/codegen/distributorsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/distributorsCodegen.ts
@@ -1,0 +1,68 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 3: Distributors codegen handlers ───────────────────────────────────
+
+export const distributorsCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_xcopies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `spacing = ${ctx.expr(d.spacing)}`
+    const n = ctx.expr(d.n); if (n !== '0' && n !== '2') params += `, n = ${n}`
+    return ctx.emitTransform(`xcopies(${params})`)
+  },
+
+  bosl2_ycopies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `spacing = ${ctx.expr(d.spacing)}`
+    const n = ctx.expr(d.n); if (n !== '0' && n !== '2') params += `, n = ${n}`
+    return ctx.emitTransform(`ycopies(${params})`)
+  },
+
+  bosl2_zcopies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `spacing = ${ctx.expr(d.spacing)}`
+    const n = ctx.expr(d.n); if (n !== '0' && n !== '2') params += `, n = ${n}`
+    return ctx.emitTransform(`zcopies(${params})`)
+  },
+
+  bosl2_grid_copies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const spacing = `[${ctx.expr(d.spacing_x)}, ${ctx.expr(d.spacing_y)}]`
+    const n = `[${ctx.expr(d.n_x)}, ${ctx.expr(d.n_y)}]`
+    let params = `spacing = ${spacing}, n = ${n}`
+    if (d.stagger) params += `, stagger = true`
+    return ctx.emitTransform(`grid_copies(${params})`)
+  },
+
+  bosl2_rot_copies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}`
+    const sa = ctx.expr(d.sa); if (sa !== '0') params += `, sa = ${sa}`
+    return ctx.emitTransform(`rot_copies(${params})`)
+  },
+
+  bosl2_arc_copies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}, r = ${ctx.expr(d.r)}`
+    const sa = ctx.expr(d.sa); if (sa !== '0') params += `, sa = ${sa}`
+    const ea = ctx.expr(d.ea); if (ea !== '360') params += `, ea = ${ea}`
+    return ctx.emitTransform(`arc_copies(${params})`)
+  },
+
+  bosl2_mirror_copy: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const v = `[${ctx.expr(d.vx)}, ${ctx.expr(d.vy)}, ${ctx.expr(d.vz)}]`
+    let params = `${v}`
+    const off = ctx.expr(d.offset); if (off !== '0') params += `, offset = ${off}`
+    return ctx.emitTransform(`mirror_copy(${params})`)
+  },
+
+  bosl2_path_copies: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const path = String(d.path ?? '[]')
+    let params = `${path}`
+    const n = ctx.expr(d.n); if (n !== '0') params += `, n = ${n}`
+    if (d.closed) params += `, closed = true`
+    return ctx.emitTransform(`path_copies(${params})`)
+  },
+}

--- a/src/nodepacks/bosl2/codegen/mechanicalCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/mechanicalCodegen.ts
@@ -1,0 +1,148 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 5: Mechanical Parts codegen handlers ──────────────────────────────
+
+function optAnchor(ctx: CodegenContext, d: Record<string, unknown>): string {
+  let extra = ''
+  const anchor = String(d.anchor ?? 'CENTER')
+  if (anchor && anchor !== 'CENTER') extra += `, anchor = ${anchor}`
+  const spin = ctx.expr(d.spin)
+  if (spin !== '0') extra += `, spin = ${spin}`
+  const orient = String(d.orient ?? 'UP')
+  if (orient && orient !== 'UP') extra += `, orient = ${orient}`
+  return extra
+}
+
+export const mechanicalCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_spur_gear: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `mod = ${ctx.expr(d.mod)}, teeth = ${ctx.expr(d.teeth)}, thickness = ${ctx.expr(d.thickness)}`
+    const pa = ctx.expr(d.pressure_angle); if (pa !== '20') params += `, pressure_angle = ${pa}`
+    const hel = ctx.expr(d.helical); if (hel !== '0') params += `, helical = ${hel}`
+    const sd = ctx.expr(d.shaft_diam); if (sd !== '0') params += `, shaft_diam = ${sd}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}spur_gear(${params});\n`
+  },
+
+  bosl2_rack: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `mod = ${ctx.expr(d.mod)}, teeth = ${ctx.expr(d.teeth)}, thickness = ${ctx.expr(d.thickness)}`
+    const pa = ctx.expr(d.pressure_angle); if (pa !== '20') params += `, pressure_angle = ${pa}`
+    const hel = ctx.expr(d.helical); if (hel !== '0') params += `, helical = ${hel}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}rack(${params});\n`
+  },
+
+  bosl2_bevel_gear: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `mod = ${ctx.expr(d.mod)}, teeth = ${ctx.expr(d.teeth)}, mate_teeth = ${ctx.expr(d.mate_teeth)}`
+    const sa = ctx.expr(d.shaft_angle); if (sa !== '90') params += `, shaft_angle = ${sa}`
+    const fw = ctx.expr(d.face_width); if (fw !== '10') params += `, face_width = ${fw}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}bevel_gear(${params});\n`
+  },
+
+  bosl2_worm: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `mod = ${ctx.expr(d.mod)}, d = ${ctx.expr(d.d)}, l = ${ctx.expr(d.l)}`
+    const st = ctx.expr(d.starts); if (st !== '1') params += `, starts = ${st}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}worm(${params});\n`
+  },
+
+  bosl2_worm_gear: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `mod = ${ctx.expr(d.mod)}, teeth = ${ctx.expr(d.teeth)}, worm_diam = ${ctx.expr(d.worm_diam)}`
+    const ws = ctx.expr(d.worm_starts); if (ws !== '1') params += `, worm_starts = ${ws}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}worm_gear(${params});\n`
+  },
+
+  bosl2_threaded_rod: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `d = ${ctx.expr(d.d)}, l = ${ctx.expr(d.l)}, pitch = ${ctx.expr(d.pitch)}`
+    if (d.internal) params += `, internal = true`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}threaded_rod(${params});\n`
+  },
+
+  bosl2_threaded_nut: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `nutwidth = ${ctx.expr(d.nutwidth)}, id = ${ctx.expr(d.id)}, h = ${ctx.expr(d.h)}, pitch = ${ctx.expr(d.pitch)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}threaded_nut(${params});\n`
+  },
+
+  bosl2_screw: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const spec = ctx.escapeString(d.spec)
+    let params = `"${spec}"`
+    const head = String(d.head ?? ''); if (head) params += `, head = "${ctx.escapeString(head)}"`
+    const drive = String(d.drive ?? ''); if (drive) params += `, drive = "${ctx.escapeString(drive)}"`
+    params += `, length = ${ctx.expr(d.length)}`
+    const tl = ctx.expr(d.thread_len); if (tl !== '0') params += `, thread_len = ${tl}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}screw(${params});\n`
+  },
+
+  bosl2_screw_hole: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const spec = ctx.escapeString(d.spec)
+    let params = `"${spec}"`
+    const head = String(d.head ?? ''); if (head) params += `, head = "${ctx.escapeString(head)}"`
+    params += `, length = ${ctx.expr(d.length)}`
+    const os = ctx.expr(d.oversize); if (os !== '0') params += `, oversize = ${os}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}screw_hole(${params});\n`
+  },
+
+  bosl2_nut: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const spec = ctx.escapeString(d.spec)
+    let params = `"${spec}"`
+    const shape = String(d.shape ?? 'hex'); if (shape !== 'hex') params += `, shape = "${shape}"`
+    params += `, thickness = ${ctx.expr(d.thickness)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}nut(${params});\n`
+  },
+
+  bosl2_dovetail: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const gender = String(d.gender ?? 'male')
+    let params = `gender = "${gender}", width = ${ctx.expr(d.width)}, height = ${ctx.expr(d.height)}`
+    params += `, slope = ${ctx.expr(d.slope)}, slide = ${ctx.expr(d.slide)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}dovetail(${params});\n`
+  },
+
+  bosl2_snap_pin: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}, l = ${ctx.expr(d.l)}`
+    const nd = ctx.expr(d.nub_depth); if (nd !== '0') params += `, nub_depth = ${nd}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}snap_pin(${params});\n`
+  },
+
+  bosl2_knuckle_hinge: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `length = ${ctx.expr(d.length)}, offset = ${ctx.expr(d.offset)}, segs = ${ctx.expr(d.segs)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}knuckle_hinge(${params});\n`
+  },
+
+  bosl2_bottle_neck: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `wall = ${ctx.expr(d.wall)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}generic_bottle_neck(${params});\n`
+  },
+
+  bosl2_bottle_cap: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `wall = ${ctx.expr(d.wall)}`
+    const tex = String(d.texture ?? ''); if (tex) params += `, texture = "${ctx.escapeString(tex)}"`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}generic_bottle_cap(${params});\n`
+  },
+}

--- a/src/nodepacks/bosl2/codegen/roundingCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/roundingCodegen.ts
@@ -1,0 +1,122 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 4: Rounding, Masks, Sweeps codegen handlers ───────────────────────
+
+function optAnchor(ctx: CodegenContext, d: Record<string, unknown>): string {
+  let extra = ''
+  const anchor = String(d.anchor ?? 'CENTER')
+  if (anchor && anchor !== 'CENTER') extra += `, anchor = ${anchor}`
+  const spin = ctx.expr(d.spin)
+  if (spin !== '0') extra += `, spin = ${spin}`
+  const orient = String(d.orient ?? 'UP')
+  if (orient && orient !== 'UP') extra += `, orient = ${orient}`
+  return extra
+}
+
+export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_offset_sweep: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `height = ${ctx.expr(d.height)}`
+    const top = ctx.expr(d.top_r); if (top !== '0') params += `, top = os_circle(r = ${top})`
+    const bot = ctx.expr(d.bot_r); if (bot !== '0') params += `, bottom = os_circle(r = ${bot})`
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`offset_sweep(${params})`)
+  },
+
+  bosl2_rounded_prism: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `height = ${ctx.expr(d.height)}`
+    const jt = ctx.expr(d.joint_top); if (jt !== '0') params += `, joint_top = ${jt}`
+    const jb = ctx.expr(d.joint_bot); if (jb !== '0') params += `, joint_bot = ${jb}`
+    const js = ctx.expr(d.joint_sides); if (js !== '0') params += `, joint_sides = ${js}`
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`rounded_prism(${params})`)
+  },
+
+  bosl2_skin: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `slices = ${ctx.expr(d.slices)}`
+    const method = String(d.method ?? 'reindex')
+    if (method !== 'reindex') params += `, method = "${method}"`
+    const style = String(d.style ?? 'min_edge')
+    if (style !== 'min_edge') params += `, style = "${style}"`
+    return ctx.emitTransform(`skin(${params})`)
+  },
+
+  bosl2_linear_sweep: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `height = ${ctx.expr(d.height)}`
+    const tw = ctx.expr(d.twist); if (tw !== '0') params += `, twist = ${tw}`
+    const sc = ctx.expr(d.scale); if (sc !== '1') params += `, scale = ${sc}`
+    const sl = ctx.expr(d.slices); if (sl !== '0') params += `, slices = ${sl}`
+    if (d.center) params += `, center = true`
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`linear_sweep(${params})`)
+  },
+
+  bosl2_rotate_sweep: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = ``
+    const ang = ctx.expr(d.angle); if (ang !== '360') params += `angle = ${ang}`
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`rotate_sweep(${params || ''})`)
+  },
+
+  bosl2_path_sweep: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = ``
+    const method = String(d.method ?? 'incremental')
+    if (method !== 'incremental') params += `method = "${method}"`
+    const tw = ctx.expr(d.twist); if (tw !== '0') { if (params) params += ', '; params += `twist = ${tw}` }
+    if (d.closed) { if (params) params += ', '; params += `closed = true` }
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`path_sweep(${params})`)
+  },
+
+  bosl2_spiral_sweep: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}, turns = ${ctx.expr(d.turns)}`
+    params += optAnchor(ctx, d)
+    return ctx.emitTransform(`spiral_sweep(${params})`)
+  },
+
+  bosl2_edge_mask: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = ``
+    const edges = String(d.edges ?? ''); if (edges) params += `${edges}`
+    const except = String(d.except ?? ''); if (except) { if (params) params += ', '; params += `except = ${except}` }
+    return ctx.emitTransform(`edge_mask(${params})`)
+  },
+
+  bosl2_corner_mask: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = ``
+    const corners = String(d.corners ?? ''); if (corners) params += `${corners}`
+    const except = String(d.except ?? ''); if (except) { if (params) params += ', '; params += `except = ${except}` }
+    return ctx.emitTransform(`corner_mask(${params})`)
+  },
+
+  bosl2_rounding_edge_mask: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}rounding_edge_mask(${params});\n`
+  },
+
+  bosl2_chamfer_edge_mask: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, chamfer = ${ctx.expr(d.chamfer)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}chamfer_edge_mask(${params});\n`
+  },
+
+  bosl2_stroke: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `width = ${ctx.expr(d.width)}`
+    if (d.closed) params += `, closed = true`
+    const ec = String(d.endcaps ?? '')
+    if (ec && ec !== 'butt') params += `, endcaps = "${ec}"`
+    return ctx.emitTransform(`stroke(${params})`)
+  },
+}

--- a/src/nodepacks/bosl2/codegen/shapes2dCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/shapes2dCodegen.ts
@@ -1,0 +1,106 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 2: 2D Shape codegen handlers ───────────────────────────────────────
+
+function optAnchor2d(ctx: CodegenContext, d: Record<string, unknown>): string {
+  let extra = ''
+  const anchor = String(d.anchor ?? 'CENTER')
+  if (anchor && anchor !== 'CENTER') extra += `, anchor = ${anchor}`
+  const spin = ctx.expr(d.spin)
+  if (spin !== '0') extra += `, spin = ${spin}`
+  return extra
+}
+
+export const shapes2dCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_rect: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}]`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    const c = ctx.expr(d.chamfer); if (c !== '0') params += `, chamfer = ${c}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}rect(${params});\n`
+  },
+
+  bosl2_ellipse: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = [${ctx.expr(d.rx)}, ${ctx.expr(d.ry)}]`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}ellipse(${params});\n`
+  },
+
+  bosl2_regular_ngon: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}, r = ${ctx.expr(d.r)}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}regular_ngon(${params});\n`
+  },
+
+  bosl2_pentagon: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}pentagon(${params});\n`
+  },
+
+  bosl2_hexagon: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}hexagon(${params});\n`
+  },
+
+  bosl2_octagon: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}octagon(${params});\n`
+  },
+
+  bosl2_star: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}, r = ${ctx.expr(d.r)}, ir = ${ctx.expr(d.ir)}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}star(${params});\n`
+  },
+
+  bosl2_trapezoid: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, w1 = ${ctx.expr(d.w1)}, w2 = ${ctx.expr(d.w2)}`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}trapezoid(${params});\n`
+  },
+
+  bosl2_right_triangle: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}]`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}right_triangle(${params});\n`
+  },
+
+  bosl2_teardrop2d: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    const ang = ctx.expr(d.ang); if (ang !== '45') params += `, ang = ${ang}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}teardrop2d(${params});\n`
+  },
+
+  bosl2_squircle: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}]`
+    const sq = ctx.expr(d.squareness); if (sq !== '0.5') params += `, squareness = ${sq}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}squircle(${params});\n`
+  },
+
+  bosl2_ring: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}, r1 = ${ctx.expr(d.r1)}, r2 = ${ctx.expr(d.r2)}`
+    params += optAnchor2d(ctx, d)
+    return `${ctx.pad}ring(${params});\n`
+  },
+}

--- a/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
@@ -1,0 +1,170 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 1: 3D Shape codegen handlers ───────────────────────────────────────
+
+function optParam(ctx: CodegenContext, name: string, val: unknown, dflt?: string): string {
+  const v = ctx.expr(val)
+  if (v === '0' && dflt === undefined) return ''
+  if (dflt !== undefined && v === dflt) return ''
+  return `, ${name} = ${v}`
+}
+
+function optAnchor(ctx: CodegenContext, d: Record<string, unknown>): string {
+  let extra = ''
+  const anchor = String(d.anchor ?? 'CENTER')
+  if (anchor && anchor !== 'CENTER') extra += `, anchor = ${anchor}`
+  const spin = ctx.expr(d.spin)
+  if (spin !== '0') extra += `, spin = ${spin}`
+  const orient = String(d.orient ?? 'UP')
+  if (orient && orient !== 'UP') extra += `, orient = ${orient}`
+  return extra
+}
+
+export const shapes3dCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_cuboid: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const size = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    let params = size
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    const c = ctx.expr(d.chamfer); if (c !== '0') params += `, chamfer = ${c}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}cuboid(${params});\n`
+  },
+
+  bosl2_cyl: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}`
+    const r1 = ctx.expr(d.r1); const r2 = ctx.expr(d.r2)
+    const r = ctx.expr(d.r)
+    if (r1 !== r2) {
+      params += `, r1 = ${r1}, r2 = ${r2}`
+    } else {
+      params += `, r = ${r}`
+    }
+    const ch = ctx.expr(d.chamfer); if (ch !== '0') params += `, chamfer = ${ch}`
+    const ro = ctx.expr(d.rounding); if (ro !== '0') params += `, rounding = ${ro}`
+    if (d.circum) params += `, circum = true`
+    const fn = ctx.expr(d.fn); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}cyl(${params});\n`
+  },
+
+  bosl2_spheroid: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    const style = String(d.style ?? 'aligned')
+    if (style !== 'aligned') params += `, style = "${style}"`
+    if (d.circum) params += `, circum = true`
+    const fn = ctx.expr(d.fn); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}spheroid(${params});\n`
+  },
+
+  bosl2_torus: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r_maj = ${ctx.expr(d.r_maj)}, r_min = ${ctx.expr(d.r_min)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}torus(${params});\n`
+  },
+
+  bosl2_tube: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, or = ${ctx.expr(d.or)}`
+    const ir = ctx.expr(d.ir); const wall = ctx.expr(d.wall)
+    if (ir !== '0') params += `, ir = ${ir}`
+    if (wall !== '0') params += `, wall = ${wall}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}tube(${params});\n`
+  },
+
+  bosl2_prismoid: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const s1 = `[${ctx.expr(d.size1_x)}, ${ctx.expr(d.size1_y)}]`
+    const s2 = `[${ctx.expr(d.size2_x)}, ${ctx.expr(d.size2_y)}]`
+    let params = `${s1}, ${s2}, h = ${ctx.expr(d.h)}`
+    const sx = ctx.expr(d.shift_x); const sy = ctx.expr(d.shift_y)
+    if (sx !== '0' || sy !== '0') params += `, shift = [${sx}, ${sy}]`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    const c = ctx.expr(d.chamfer); if (c !== '0') params += `, chamfer = ${c}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}prismoid(${params});\n`
+  },
+
+  bosl2_wedge: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}wedge(${params});\n`
+  },
+
+  bosl2_pie_slice: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}, ang = ${ctx.expr(d.ang)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}pie_slice(${params});\n`
+  },
+
+  bosl2_teardrop: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
+    const ang = ctx.expr(d.ang); if (ang !== '45') params += `, ang = ${ang}`
+    const cap = ctx.expr(d.cap_h); if (cap !== '0') params += `, cap_h = ${cap}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}teardrop(${params});\n`
+  },
+
+  bosl2_onion: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `r = ${ctx.expr(d.r)}`
+    const ang = ctx.expr(d.ang); if (ang !== '45') params += `, ang = ${ang}`
+    const cap = ctx.expr(d.cap_h); if (cap !== '0') params += `, cap_h = ${cap}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}onion(${params});\n`
+  },
+
+  bosl2_rect_tube: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const size = `[${ctx.expr(d.size_x)}, ${ctx.expr(d.size_y)}]`
+    const isize = `[${ctx.expr(d.isize_x)}, ${ctx.expr(d.isize_y)}]`
+    let params = `h = ${ctx.expr(d.h)}, size = ${size}, isize = ${isize}`
+    const wall = ctx.expr(d.wall); if (wall !== '0') params += `, wall = ${wall}`
+    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}rect_tube(${params});\n`
+  },
+
+  bosl2_octahedron: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `size = ${ctx.expr(d.size)}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}octahedron(${params});\n`
+  },
+
+  bosl2_regular_prism: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `n = ${ctx.expr(d.n)}, h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
+    const ro = ctx.expr(d.rounding); if (ro !== '0') params += `, rounding = ${ro}`
+    const ch = ctx.expr(d.chamfer); if (ch !== '0') params += `, chamfer = ${ch}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}regular_prism(${params});\n`
+  },
+
+  bosl2_text3d: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const text = ctx.escapeString(d.text)
+    let params = `"${text}", h = ${ctx.expr(d.h)}, size = ${ctx.expr(d.size)}`
+    const font = String(d.font ?? '')
+    if (font) params += `, font = "${ctx.escapeString(font)}"`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}text3d(${params});\n`
+  },
+
+  bosl2_fillet: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
+    const ang = ctx.expr(d.ang); if (ang !== '90') params += `, ang = ${ang}`
+    params += optAnchor(ctx, d)
+    return `${ctx.pad}fillet(${params});\n`
+  },
+}

--- a/src/nodepacks/bosl2/codegen/transformsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/transformsCodegen.ts
@@ -1,0 +1,100 @@
+import type { Node } from '@xyflow/react'
+import type { CodegenContext } from '@/types/nodePack'
+
+// ─── Tier 3: Transforms codegen handlers ─────────────────────────────────────
+
+export const transformsCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
+  bosl2_move: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`move([${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}])`)
+  },
+
+  bosl2_left: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`left(${ctx.expr(d.d)})`)
+  },
+  bosl2_right: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`right(${ctx.expr(d.d)})`)
+  },
+  bosl2_fwd: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`fwd(${ctx.expr(d.d)})`)
+  },
+  bosl2_back: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`back(${ctx.expr(d.d)})`)
+  },
+  bosl2_up: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`up(${ctx.expr(d.d)})`)
+  },
+  bosl2_down: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`down(${ctx.expr(d.d)})`)
+  },
+
+  bosl2_rot: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const a = ctx.expr(d.a)
+    const vx = ctx.expr(d.vx); const vy = ctx.expr(d.vy); const vz = ctx.expr(d.vz)
+    if (vx !== '0' || vy !== '0' || vz !== '0') {
+      return ctx.emitTransform(`rot(a = ${a}, v = [${vx}, ${vy}, ${vz}])`)
+    }
+    return ctx.emitTransform(`rot(${a})`)
+  },
+
+  bosl2_xrot: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`xrot(${ctx.expr(d.a)})`)
+  },
+  bosl2_yrot: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`yrot(${ctx.expr(d.a)})`)
+  },
+  bosl2_zrot: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`zrot(${ctx.expr(d.a)})`)
+  },
+
+  bosl2_xscale: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`xscale(${ctx.expr(d.factor)})`)
+  },
+  bosl2_yscale: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`yscale(${ctx.expr(d.factor)})`)
+  },
+  bosl2_zscale: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    return ctx.emitTransform(`zscale(${ctx.expr(d.factor)})`)
+  },
+
+  bosl2_xflip: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const off = ctx.expr(d.offset)
+    return ctx.emitTransform(off !== '0' ? `xflip(x = ${off})` : `xflip()`)
+  },
+  bosl2_yflip: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const off = ctx.expr(d.offset)
+    return ctx.emitTransform(off !== '0' ? `yflip(y = ${off})` : `yflip()`)
+  },
+  bosl2_zflip: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const off = ctx.expr(d.offset)
+    return ctx.emitTransform(off !== '0' ? `zflip(z = ${off})` : `zflip()`)
+  },
+
+  bosl2_skew: (node, ctx) => {
+    const d = node.data as Record<string, unknown>
+    const parts: string[] = []
+    const add = (name: string, val: unknown) => {
+      const v = ctx.expr(val); if (v !== '0') parts.push(`${name} = ${v}`)
+    }
+    add('sxy', d.sxy); add('sxz', d.sxz)
+    add('syx', d.syx); add('syz', d.syz)
+    add('szx', d.szx); add('szy', d.szy)
+    return ctx.emitTransform(`skew(${parts.join(', ')})`)
+  },
+}

--- a/src/nodepacks/bosl2/index.ts
+++ b/src/nodepacks/bosl2/index.ts
@@ -1,0 +1,307 @@
+import type { Node } from '@xyflow/react'
+import type { NodePackDefinition } from '@/types/nodePack'
+import { bosl2Preamble } from './preamble'
+
+// ─── Node components ─────────────────────────────────────────────────────────
+
+// Tier 1: 3D Shape Primitives
+import { CuboidNode } from './nodes/shapes3d/CuboidNode'
+import { CylNode } from './nodes/shapes3d/CylNode'
+import { SpheroidNode } from './nodes/shapes3d/SpheroidNode'
+import { TorusNode } from './nodes/shapes3d/TorusNode'
+import { TubeNode } from './nodes/shapes3d/TubeNode'
+import { PrismoidNode } from './nodes/shapes3d/PrismoidNode'
+import { WedgeNode } from './nodes/shapes3d/WedgeNode'
+import { PieSliceNode } from './nodes/shapes3d/PieSliceNode'
+import { TeardropNode } from './nodes/shapes3d/TeardropNode'
+import { OnionNode } from './nodes/shapes3d/OnionNode'
+import { RectTubeNode } from './nodes/shapes3d/RectTubeNode'
+import { OctahedronNode } from './nodes/shapes3d/OctahedronNode'
+import { RegularPrismNode } from './nodes/shapes3d/RegularPrismNode'
+import { Text3dNode } from './nodes/shapes3d/Text3dNode'
+import { FilletNode } from './nodes/shapes3d/FilletNode'
+
+// Tier 2: 2D Shape Primitives
+import { RectNode } from './nodes/shapes2d/RectNode'
+import { EllipseNode } from './nodes/shapes2d/EllipseNode'
+import { RegularNgonNode } from './nodes/shapes2d/RegularNgonNode'
+import { PentagonNode } from './nodes/shapes2d/PentagonNode'
+import { HexagonNode } from './nodes/shapes2d/HexagonNode'
+import { OctagonNode } from './nodes/shapes2d/OctagonNode'
+import { StarNode } from './nodes/shapes2d/StarNode'
+import { TrapezoidNode } from './nodes/shapes2d/TrapezoidNode'
+import { RightTriangleNode } from './nodes/shapes2d/RightTriangleNode'
+import { Teardrop2dNode } from './nodes/shapes2d/Teardrop2dNode'
+import { SquircleNode } from './nodes/shapes2d/SquircleNode'
+import { RingNode } from './nodes/shapes2d/RingNode'
+
+// Tier 3: Transforms
+import { MoveNode } from './nodes/transforms/MoveNode'
+import { LeftNode } from './nodes/transforms/LeftNode'
+import { RightNode } from './nodes/transforms/RightNode'
+import { FwdNode } from './nodes/transforms/FwdNode'
+import { BackNode } from './nodes/transforms/BackNode'
+import { UpNode } from './nodes/transforms/UpNode'
+import { DownNode } from './nodes/transforms/DownNode'
+import { RotNode } from './nodes/transforms/RotNode'
+import { XrotNode } from './nodes/transforms/XrotNode'
+import { YrotNode } from './nodes/transforms/YrotNode'
+import { ZrotNode } from './nodes/transforms/ZrotNode'
+import { XscaleNode } from './nodes/transforms/XscaleNode'
+import { YscaleNode } from './nodes/transforms/YscaleNode'
+import { ZscaleNode } from './nodes/transforms/ZscaleNode'
+import { XflipNode } from './nodes/transforms/XflipNode'
+import { YflipNode } from './nodes/transforms/YflipNode'
+import { ZflipNode } from './nodes/transforms/ZflipNode'
+import { SkewNode } from './nodes/transforms/SkewNode'
+
+// Tier 3: Distributors
+import { XcopiesNode } from './nodes/distributors/XcopiesNode'
+import { YcopiesNode } from './nodes/distributors/YcopiesNode'
+import { ZcopiesNode } from './nodes/distributors/ZcopiesNode'
+import { GridCopiesNode } from './nodes/distributors/GridCopiesNode'
+import { RotCopiesNode } from './nodes/distributors/RotCopiesNode'
+import { ArcCopiesNode } from './nodes/distributors/ArcCopiesNode'
+import { MirrorCopyNode } from './nodes/distributors/MirrorCopyNode'
+import { PathCopiesNode } from './nodes/distributors/PathCopiesNode'
+
+// Tier 4: Rounding, Masks, Sweeps
+import { OffsetSweepNode } from './nodes/rounding/OffsetSweepNode'
+import { RoundedPrismNode } from './nodes/rounding/RoundedPrismNode'
+import { SkinNode } from './nodes/rounding/SkinNode'
+import { LinearSweepNode } from './nodes/rounding/LinearSweepNode'
+import { RotateSweepNode } from './nodes/rounding/RotateSweepNode'
+import { PathSweepNode } from './nodes/rounding/PathSweepNode'
+import { SpiralSweepNode } from './nodes/rounding/SpiralSweepNode'
+import { EdgeMaskNode } from './nodes/rounding/EdgeMaskNode'
+import { CornerMaskNode } from './nodes/rounding/CornerMaskNode'
+import { RoundingEdgeMaskNode } from './nodes/rounding/RoundingEdgeMaskNode'
+import { ChamferEdgeMaskNode } from './nodes/rounding/ChamferEdgeMaskNode'
+import { StrokeNode } from './nodes/rounding/StrokeNode'
+
+// Tier 5: Mechanical Parts
+import { SpurGearNode } from './nodes/mechanical/SpurGearNode'
+import { RackNode } from './nodes/mechanical/RackNode'
+import { BevelGearNode } from './nodes/mechanical/BevelGearNode'
+import { WormNode } from './nodes/mechanical/WormNode'
+import { WormGearNode } from './nodes/mechanical/WormGearNode'
+import { ThreadedRodNode } from './nodes/mechanical/ThreadedRodNode'
+import { ThreadedNutNode } from './nodes/mechanical/ThreadedNutNode'
+import { ScrewNode } from './nodes/mechanical/ScrewNode'
+import { ScrewHoleNode } from './nodes/mechanical/ScrewHoleNode'
+import { NutNode } from './nodes/mechanical/NutNode'
+import { DovetailNode } from './nodes/mechanical/DovetailNode'
+import { SnapPinNode } from './nodes/mechanical/SnapPinNode'
+import { KnuckleHingeNode } from './nodes/mechanical/KnuckleHingeNode'
+import { BottleNeckNode } from './nodes/mechanical/BottleNeckNode'
+import { BottleCapNode } from './nodes/mechanical/BottleCapNode'
+
+// Tier 6: Attachments & Advanced
+import { DiffNode } from './nodes/attachments/DiffNode'
+import { IntersectNode } from './nodes/attachments/IntersectNode'
+import { PositionNode } from './nodes/attachments/PositionNode'
+import { AttachNode } from './nodes/attachments/AttachNode'
+import { TagNode } from './nodes/attachments/TagNode'
+import { RecolorNode } from './nodes/attachments/RecolorNode'
+import { HalfOfNode } from './nodes/attachments/HalfOfNode'
+import { PartitionNode } from './nodes/attachments/PartitionNode'
+
+// ─── Codegen handlers ────────────────────────────────────────────────────────
+
+import { shapes3dCodegen } from './codegen/shapes3dCodegen'
+import { shapes2dCodegen } from './codegen/shapes2dCodegen'
+import { transformsCodegen } from './codegen/transformsCodegen'
+import { distributorsCodegen } from './codegen/distributorsCodegen'
+import { roundingCodegen } from './codegen/roundingCodegen'
+import { mechanicalCodegen } from './codegen/mechanicalCodegen'
+import { attachmentsCodegen } from './codegen/attachmentsCodegen'
+
+// ─── Palette definitions ─────────────────────────────────────────────────────
+
+import { SHAPES3D_PALETTE } from './palette/shapes3dPalette'
+import { SHAPES2D_PALETTE } from './palette/shapes2dPalette'
+import { TRANSFORMS_PALETTE, DISTRIBUTORS_PALETTE } from './palette/transformsPalette'
+import { ROUNDING_PALETTE } from './palette/roundingPalette'
+import { MECHANICAL_PALETTE } from './palette/mechanicalPalette'
+import { ATTACHMENTS_PALETTE } from './palette/attachmentsPalette'
+
+// ─── Pack definitions (Option A: one pack per sub-category) ──────────────────
+
+export const bosl2Shapes3dPack: NodePackDefinition = {
+  id: 'bosl2_shapes3d',
+  category: 'bosl2_shapes3d',
+  categoryLabel: 'BOSL2 3D Shapes',
+  categoryColor: 'bg-indigo-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_cuboid: CuboidNode,
+    bosl2_cyl: CylNode,
+    bosl2_spheroid: SpheroidNode,
+    bosl2_torus: TorusNode,
+    bosl2_tube: TubeNode,
+    bosl2_prismoid: PrismoidNode,
+    bosl2_wedge: WedgeNode,
+    bosl2_pie_slice: PieSliceNode,
+    bosl2_teardrop: TeardropNode,
+    bosl2_onion: OnionNode,
+    bosl2_rect_tube: RectTubeNode,
+    bosl2_octahedron: OctahedronNode,
+    bosl2_regular_prism: RegularPrismNode,
+    bosl2_text3d: Text3dNode,
+    bosl2_fillet: FilletNode,
+  },
+  paletteItems: SHAPES3D_PALETTE,
+  codegenHandlers: shapes3dCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2Shapes2dPack: NodePackDefinition = {
+  id: 'bosl2_shapes2d',
+  category: 'bosl2_shapes2d',
+  categoryLabel: 'BOSL2 2D Shapes',
+  categoryColor: 'bg-teal-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_rect: RectNode,
+    bosl2_ellipse: EllipseNode,
+    bosl2_regular_ngon: RegularNgonNode,
+    bosl2_pentagon: PentagonNode,
+    bosl2_hexagon: HexagonNode,
+    bosl2_octagon: OctagonNode,
+    bosl2_star: StarNode,
+    bosl2_trapezoid: TrapezoidNode,
+    bosl2_right_triangle: RightTriangleNode,
+    bosl2_teardrop2d: Teardrop2dNode,
+    bosl2_squircle: SquircleNode,
+    bosl2_ring: RingNode,
+  },
+  paletteItems: SHAPES2D_PALETTE,
+  codegenHandlers: shapes2dCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2TransformsPack: NodePackDefinition = {
+  id: 'bosl2_transforms',
+  category: 'bosl2_transforms',
+  categoryLabel: 'BOSL2 Transforms',
+  categoryColor: 'bg-amber-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_move: MoveNode,
+    bosl2_left: LeftNode,
+    bosl2_right: RightNode,
+    bosl2_fwd: FwdNode,
+    bosl2_back: BackNode,
+    bosl2_up: UpNode,
+    bosl2_down: DownNode,
+    bosl2_rot: RotNode,
+    bosl2_xrot: XrotNode,
+    bosl2_yrot: YrotNode,
+    bosl2_zrot: ZrotNode,
+    bosl2_xscale: XscaleNode,
+    bosl2_yscale: YscaleNode,
+    bosl2_zscale: ZscaleNode,
+    bosl2_xflip: XflipNode,
+    bosl2_yflip: YflipNode,
+    bosl2_zflip: ZflipNode,
+    bosl2_skew: SkewNode,
+  },
+  paletteItems: TRANSFORMS_PALETTE,
+  codegenHandlers: transformsCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2DistributorsPack: NodePackDefinition = {
+  id: 'bosl2_distributors',
+  category: 'bosl2_distributors',
+  categoryLabel: 'BOSL2 Distributors',
+  categoryColor: 'bg-lime-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_xcopies: XcopiesNode,
+    bosl2_ycopies: YcopiesNode,
+    bosl2_zcopies: ZcopiesNode,
+    bosl2_grid_copies: GridCopiesNode,
+    bosl2_rot_copies: RotCopiesNode,
+    bosl2_arc_copies: ArcCopiesNode,
+    bosl2_mirror_copy: MirrorCopyNode,
+    bosl2_path_copies: PathCopiesNode,
+  },
+  paletteItems: DISTRIBUTORS_PALETTE,
+  codegenHandlers: distributorsCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2RoundingPack: NodePackDefinition = {
+  id: 'bosl2_rounding',
+  category: 'bosl2_rounding',
+  categoryLabel: 'BOSL2 Rounding & Sweeps',
+  categoryColor: 'bg-violet-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_offset_sweep: OffsetSweepNode,
+    bosl2_rounded_prism: RoundedPrismNode,
+    bosl2_skin: SkinNode,
+    bosl2_linear_sweep: LinearSweepNode,
+    bosl2_rotate_sweep: RotateSweepNode,
+    bosl2_path_sweep: PathSweepNode,
+    bosl2_spiral_sweep: SpiralSweepNode,
+    bosl2_edge_mask: EdgeMaskNode,
+    bosl2_corner_mask: CornerMaskNode,
+    bosl2_rounding_edge_mask: RoundingEdgeMaskNode,
+    bosl2_chamfer_edge_mask: ChamferEdgeMaskNode,
+    bosl2_stroke: StrokeNode,
+  },
+  paletteItems: ROUNDING_PALETTE,
+  codegenHandlers: roundingCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2MechanicalPack: NodePackDefinition = {
+  id: 'bosl2_mechanical',
+  category: 'bosl2_mechanical',
+  categoryLabel: 'BOSL2 Mechanical',
+  categoryColor: 'bg-rose-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_spur_gear: SpurGearNode,
+    bosl2_rack: RackNode,
+    bosl2_bevel_gear: BevelGearNode,
+    bosl2_worm: WormNode,
+    bosl2_worm_gear: WormGearNode,
+    bosl2_threaded_rod: ThreadedRodNode,
+    bosl2_threaded_nut: ThreadedNutNode,
+    bosl2_screw: ScrewNode,
+    bosl2_screw_hole: ScrewHoleNode,
+    bosl2_nut: NutNode,
+    bosl2_dovetail: DovetailNode,
+    bosl2_snap_pin: SnapPinNode,
+    bosl2_knuckle_hinge: KnuckleHingeNode,
+    bosl2_bottle_neck: BottleNeckNode,
+    bosl2_bottle_cap: BottleCapNode,
+  },
+  paletteItems: MECHANICAL_PALETTE,
+  codegenHandlers: mechanicalCodegen,
+  preamble: bosl2Preamble,
+}
+
+export const bosl2AttachmentsPack: NodePackDefinition = {
+  id: 'bosl2_attachments',
+  category: 'bosl2_attachments',
+  categoryLabel: 'BOSL2 Attachments',
+  categoryColor: 'bg-sky-600',
+  categoryTextColor: 'text-white',
+  nodeTypes: {
+    bosl2_diff: DiffNode,
+    bosl2_intersect: IntersectNode,
+    bosl2_position: PositionNode,
+    bosl2_attach: AttachNode,
+    bosl2_tag: TagNode,
+    bosl2_recolor: RecolorNode,
+    bosl2_half_of: HalfOfNode,
+    bosl2_partition: PartitionNode,
+  },
+  paletteItems: ATTACHMENTS_PALETTE,
+  codegenHandlers: attachmentsCodegen,
+  preamble: bosl2Preamble,
+}

--- a/src/nodepacks/bosl2/index.ts
+++ b/src/nodepacks/bosl2/index.ts
@@ -126,6 +126,10 @@ import { MECHANICAL_PALETTE } from './palette/mechanicalPalette'
 import { ATTACHMENTS_PALETTE } from './palette/attachmentsPalette'
 
 // ─── Pack definitions (Option A: one pack per sub-category) ──────────────────
+// NOTE: preamble is assigned to bosl2Shapes3dPack ONLY.
+// The codegen pipeline calls pack.preamble(nodes) for every registered pack, so
+// assigning bosl2Preamble to all 7 packs would emit the includes 7× in the
+// generated output. One pack owns the preamble; the others omit the field.
 
 export const bosl2Shapes3dPack: NodePackDefinition = {
   id: 'bosl2_shapes3d',
@@ -177,7 +181,6 @@ export const bosl2Shapes2dPack: NodePackDefinition = {
   },
   paletteItems: SHAPES2D_PALETTE,
   codegenHandlers: shapes2dCodegen,
-  preamble: bosl2Preamble,
 }
 
 export const bosl2TransformsPack: NodePackDefinition = {
@@ -208,7 +211,6 @@ export const bosl2TransformsPack: NodePackDefinition = {
   },
   paletteItems: TRANSFORMS_PALETTE,
   codegenHandlers: transformsCodegen,
-  preamble: bosl2Preamble,
 }
 
 export const bosl2DistributorsPack: NodePackDefinition = {
@@ -229,7 +231,6 @@ export const bosl2DistributorsPack: NodePackDefinition = {
   },
   paletteItems: DISTRIBUTORS_PALETTE,
   codegenHandlers: distributorsCodegen,
-  preamble: bosl2Preamble,
 }
 
 export const bosl2RoundingPack: NodePackDefinition = {
@@ -254,7 +255,6 @@ export const bosl2RoundingPack: NodePackDefinition = {
   },
   paletteItems: ROUNDING_PALETTE,
   codegenHandlers: roundingCodegen,
-  preamble: bosl2Preamble,
 }
 
 export const bosl2MechanicalPack: NodePackDefinition = {
@@ -282,7 +282,6 @@ export const bosl2MechanicalPack: NodePackDefinition = {
   },
   paletteItems: MECHANICAL_PALETTE,
   codegenHandlers: mechanicalCodegen,
-  preamble: bosl2Preamble,
 }
 
 export const bosl2AttachmentsPack: NodePackDefinition = {
@@ -303,5 +302,4 @@ export const bosl2AttachmentsPack: NodePackDefinition = {
   },
   paletteItems: ATTACHMENTS_PALETTE,
   codegenHandlers: attachmentsCodegen,
-  preamble: bosl2Preamble,
 }

--- a/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AttachData } from '../../types/attachments'
+
+export function AttachNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AttachData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="attach" selected={selected}>
+      <TextInput label="parent" value={d.parent} onChange={(v) => update(id, { parent: v })} />
+      <TextInput label="child" value={d.child} onChange={(v) => update(id, { child: v })} />
+      <ExpressionInput label="overlap" value={d.overlap} step={0.5} onChange={(v) => update(id, { overlap: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/DiffNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/DiffNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DiffData } from '../../types/attachments'
+
+export function DiffNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DiffData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="diff" selected={selected}>
+      <TextInput label="remove" value={d.remove} onChange={(v) => update(id, { remove: v })} />
+      <TextInput label="keep" value={d.keep} onChange={(v) => update(id, { keep: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/HalfOfNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/HalfOfNode.tsx
@@ -1,0 +1,19 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2HalfOfData } from '../../types/attachments'
+
+export function HalfOfNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2HalfOfData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="half_of" selected={selected}>
+      <ExpressionInput label="vx" value={d.vx} step={1} onChange={(v) => update(id, { vx: v })} />
+      <ExpressionInput label="vy" value={d.vy} step={1} onChange={(v) => update(id, { vy: v })} />
+      <ExpressionInput label="vz" value={d.vz} step={1} onChange={(v) => update(id, { vz: v })} />
+      <ExpressionInput label="cpx" value={d.cpx} step={1} onChange={(v) => update(id, { cpx: v })} />
+      <ExpressionInput label="cpy" value={d.cpy} step={1} onChange={(v) => update(id, { cpy: v })} />
+      <ExpressionInput label="cpz" value={d.cpz} step={1} onChange={(v) => update(id, { cpz: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/IntersectNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/IntersectNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2IntersectData } from '../../types/attachments'
+
+export function IntersectNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2IntersectData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="intersect" selected={selected}>
+      <TextInput label="intersect" value={d.intersect} onChange={(v) => update(id, { intersect: v })} />
+      <TextInput label="keep" value={d.keep} onChange={(v) => update(id, { keep: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/PartitionNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/PartitionNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PartitionData } from '../../types/attachments'
+
+export function PartitionNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PartitionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="partition" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
+      <ExpressionInput label="spread" value={d.spread} step={1} onChange={(v) => update(id, { spread: v })} />
+      <TextInput label="cutpath" value={d.cutpath} onChange={(v) => update(id, { cutpath: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/PositionNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/PositionNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PositionData } from '../../types/attachments'
+
+export function PositionNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PositionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="position" selected={selected}>
+      <TextInput label="at" value={d.at} onChange={(v) => update(id, { at: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/RecolorNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/RecolorNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RecolorData } from '../../types/attachments'
+
+export function RecolorNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RecolorData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="recolor" selected={selected}>
+      <TextInput label="c" value={d.c} onChange={(v) => update(id, { c: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/attachments/TagNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/TagNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2TagData } from '../../types/attachments'
+
+export function TagNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2TagData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_attachments" label="tag" selected={selected}>
+      <TextInput label="tag" value={d.tag} onChange={(v) => update(id, { tag: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/ArcCopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/ArcCopiesNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ArcCopiesData } from '../../types/transforms'
+
+export function ArcCopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ArcCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="arc_copies" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="sa" value={d.sa} step={1} onChange={(v) => update(id, { sa: v })} />
+      <ExpressionInput label="ea" value={d.ea} step={1} onChange={(v) => update(id, { ea: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/GridCopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/GridCopiesNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2GridCopiesData } from '../../types/transforms'
+
+export function GridCopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2GridCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="grid_copies" selected={selected}>
+      <ExpressionInput label="spacing_x" value={d.spacing_x} step={1} onChange={(v) => update(id, { spacing_x: v })} />
+      <ExpressionInput label="spacing_y" value={d.spacing_y} step={1} onChange={(v) => update(id, { spacing_y: v })} />
+      <ExpressionInput label="n_x" value={d.n_x} step={1} onChange={(v) => update(id, { n_x: v })} />
+      <ExpressionInput label="n_y" value={d.n_y} step={1} onChange={(v) => update(id, { n_y: v })} />
+      <CheckboxInput label="stagger" value={d.stagger} onChange={(v) => update(id, { stagger: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/MirrorCopyNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/MirrorCopyNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2MirrorCopyData } from '../../types/transforms'
+
+export function MirrorCopyNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2MirrorCopyData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="mirror_copy" selected={selected}>
+      <ExpressionInput label="vx" value={d.vx} step={1} onChange={(v) => update(id, { vx: v })} />
+      <ExpressionInput label="vy" value={d.vy} step={1} onChange={(v) => update(id, { vy: v })} />
+      <ExpressionInput label="vz" value={d.vz} step={1} onChange={(v) => update(id, { vz: v })} />
+      <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/PathCopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/PathCopiesNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput, CheckboxInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PathCopiesData } from '../../types/transforms'
+
+export function PathCopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PathCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="path_copies" selected={selected}>
+      <TextInput label="path" value={d.path} onChange={(v) => update(id, { path: v })} />
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/RotCopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/RotCopiesNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RotCopiesData } from '../../types/transforms'
+
+export function RotCopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RotCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="rot_copies" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="sa" value={d.sa} step={1} onChange={(v) => update(id, { sa: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/XcopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/XcopiesNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisCopiesData } from '../../types/transforms'
+
+export function XcopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="xcopies" selected={selected}>
+      <ExpressionInput label="spacing" value={d.spacing} step={1} onChange={(v) => update(id, { spacing: v })} />
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/YcopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/YcopiesNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisCopiesData } from '../../types/transforms'
+
+export function YcopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="ycopies" selected={selected}>
+      <ExpressionInput label="spacing" value={d.spacing} step={1} onChange={(v) => update(id, { spacing: v })} />
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/distributors/ZcopiesNode.tsx
+++ b/src/nodepacks/bosl2/nodes/distributors/ZcopiesNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisCopiesData } from '../../types/transforms'
+
+export function ZcopiesNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisCopiesData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_distributors" label="zcopies" selected={selected}>
+      <ExpressionInput label="spacing" value={d.spacing} step={1} onChange={(v) => update(id, { spacing: v })} />
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/BevelGearNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/BevelGearNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2BevelGearData } from '../../types/mechanical'
+
+export function BevelGearNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2BevelGearData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="bevel_gear" selected={selected}>
+      <ExpressionInput label="mod" value={d.mod} step={0.5} onChange={(v) => update(id, { mod: v })} />
+      <ExpressionInput label="teeth" value={d.teeth} step={1} onChange={(v) => update(id, { teeth: v })} />
+      <ExpressionInput label="mate_teeth" value={d.mate_teeth} step={1} onChange={(v) => update(id, { mate_teeth: v })} />
+      <ExpressionInput label="shaft_angle" value={d.shaft_angle} step={1} onChange={(v) => update(id, { shaft_angle: v })} />
+      <ExpressionInput label="face_width" value={d.face_width} step={1} onChange={(v) => update(id, { face_width: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/BottleCapNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/BottleCapNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2BottleCapData } from '../../types/mechanical'
+
+export function BottleCapNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2BottleCapData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="bottle_cap" selected={selected}>
+      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
+      <TextInput label="texture" value={d.texture} onChange={(v) => update(id, { texture: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/BottleNeckNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/BottleNeckNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2BottleNeckData } from '../../types/mechanical'
+
+export function BottleNeckNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2BottleNeckData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="bottle_neck" selected={selected}>
+      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/DovetailNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/DovetailNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DovetailData } from '../../types/mechanical'
+
+export function DovetailNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DovetailData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="dovetail" selected={selected}>
+      <SelectInput label="gender" value={d.gender} options={["male", "female"]} onChange={(v) => update(id, { gender: v })} />
+      <ExpressionInput label="width" value={d.width} step={1} onChange={(v) => update(id, { width: v })} />
+      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="slope" value={d.slope} step={1} onChange={(v) => update(id, { slope: v })} />
+      <ExpressionInput label="slide" value={d.slide} step={1} onChange={(v) => update(id, { slide: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/KnuckleHingeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/KnuckleHingeNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2KnuckleHingeData } from '../../types/mechanical'
+
+export function KnuckleHingeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2KnuckleHingeData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="knuckle_hinge" selected={selected}>
+      <ExpressionInput label="length" value={d.length} step={1} onChange={(v) => update(id, { length: v })} />
+      <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
+      <ExpressionInput label="segs" value={d.segs} step={1} onChange={(v) => update(id, { segs: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/NutNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/NutNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2NutData } from '../../types/mechanical'
+
+export function NutNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2NutData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="nut" selected={selected}>
+      <TextInput label="spec" value={d.spec} onChange={(v) => update(id, { spec: v })} />
+      <SelectInput label="shape" value={d.shape} options={["hex", "square"]} onChange={(v) => update(id, { shape: v })} />
+      <ExpressionInput label="thickness" value={d.thickness} step={0.1} onChange={(v) => update(id, { thickness: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/RackNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/RackNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RackData } from '../../types/mechanical'
+
+export function RackNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RackData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="rack" selected={selected}>
+      <ExpressionInput label="mod" value={d.mod} step={0.5} onChange={(v) => update(id, { mod: v })} />
+      <ExpressionInput label="teeth" value={d.teeth} step={1} onChange={(v) => update(id, { teeth: v })} />
+      <ExpressionInput label="thickness" value={d.thickness} step={1} onChange={(v) => update(id, { thickness: v })} />
+      <ExpressionInput label="pressure_angle" value={d.pressure_angle} step={1} onChange={(v) => update(id, { pressure_angle: v })} />
+      <ExpressionInput label="helical" value={d.helical} step={1} onChange={(v) => update(id, { helical: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/ScrewHoleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/ScrewHoleNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ScrewHoleData } from '../../types/mechanical'
+
+export function ScrewHoleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ScrewHoleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="screw_hole" selected={selected}>
+      <TextInput label="spec" value={d.spec} onChange={(v) => update(id, { spec: v })} />
+      <TextInput label="head" value={d.head} onChange={(v) => update(id, { head: v })} />
+      <ExpressionInput label="length" value={d.length} step={1} onChange={(v) => update(id, { length: v })} />
+      <ExpressionInput label="oversize" value={d.oversize} step={0.1} onChange={(v) => update(id, { oversize: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/ScrewNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/ScrewNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ScrewData } from '../../types/mechanical'
+
+export function ScrewNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ScrewData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="screw" selected={selected}>
+      <TextInput label="spec" value={d.spec} onChange={(v) => update(id, { spec: v })} />
+      <TextInput label="head" value={d.head} onChange={(v) => update(id, { head: v })} />
+      <TextInput label="drive" value={d.drive} onChange={(v) => update(id, { drive: v })} />
+      <ExpressionInput label="length" value={d.length} step={1} onChange={(v) => update(id, { length: v })} />
+      <ExpressionInput label="thread_len" value={d.thread_len} step={1} onChange={(v) => update(id, { thread_len: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/SnapPinNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/SnapPinNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SnapPinData } from '../../types/mechanical'
+
+export function SnapPinNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SnapPinData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="snap_pin" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={0.5} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="l" value={d.l} step={1} onChange={(v) => update(id, { l: v })} />
+      <ExpressionInput label="nub_depth" value={d.nub_depth} step={0.1} onChange={(v) => update(id, { nub_depth: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/SpurGearNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/SpurGearNode.tsx
@@ -1,0 +1,19 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SpurGearData } from '../../types/mechanical'
+
+export function SpurGearNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SpurGearData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="spur_gear" selected={selected}>
+      <ExpressionInput label="mod" value={d.mod} step={0.5} onChange={(v) => update(id, { mod: v })} />
+      <ExpressionInput label="teeth" value={d.teeth} step={1} onChange={(v) => update(id, { teeth: v })} />
+      <ExpressionInput label="thickness" value={d.thickness} step={1} onChange={(v) => update(id, { thickness: v })} />
+      <ExpressionInput label="pressure_angle" value={d.pressure_angle} step={1} onChange={(v) => update(id, { pressure_angle: v })} />
+      <ExpressionInput label="helical" value={d.helical} step={1} onChange={(v) => update(id, { helical: v })} />
+      <ExpressionInput label="shaft_diam" value={d.shaft_diam} step={1} onChange={(v) => update(id, { shaft_diam: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/ThreadedNutNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/ThreadedNutNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ThreadedNutData } from '../../types/mechanical'
+
+export function ThreadedNutNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ThreadedNutData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="threaded_nut" selected={selected}>
+      <ExpressionInput label="nutwidth" value={d.nutwidth} step={1} onChange={(v) => update(id, { nutwidth: v })} />
+      <ExpressionInput label="id" value={d.id} step={1} onChange={(v) => update(id, { id: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="pitch" value={d.pitch} step={0.5} onChange={(v) => update(id, { pitch: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/ThreadedRodNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/ThreadedRodNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ThreadedRodData } from '../../types/mechanical'
+
+export function ThreadedRodNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ThreadedRodData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="threaded_rod" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+      <ExpressionInput label="l" value={d.l} step={1} onChange={(v) => update(id, { l: v })} />
+      <ExpressionInput label="pitch" value={d.pitch} step={0.5} onChange={(v) => update(id, { pitch: v })} />
+      <CheckboxInput label="internal" value={d.internal} onChange={(v) => update(id, { internal: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/WormGearNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/WormGearNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2WormGearData } from '../../types/mechanical'
+
+export function WormGearNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2WormGearData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="worm_gear" selected={selected}>
+      <ExpressionInput label="mod" value={d.mod} step={0.5} onChange={(v) => update(id, { mod: v })} />
+      <ExpressionInput label="teeth" value={d.teeth} step={1} onChange={(v) => update(id, { teeth: v })} />
+      <ExpressionInput label="worm_diam" value={d.worm_diam} step={1} onChange={(v) => update(id, { worm_diam: v })} />
+      <ExpressionInput label="worm_starts" value={d.worm_starts} step={1} onChange={(v) => update(id, { worm_starts: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/mechanical/WormNode.tsx
+++ b/src/nodepacks/bosl2/nodes/mechanical/WormNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2WormData } from '../../types/mechanical'
+
+export function WormNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2WormData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_mechanical" label="worm" selected={selected}>
+      <ExpressionInput label="mod" value={d.mod} step={0.5} onChange={(v) => update(id, { mod: v })} />
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+      <ExpressionInput label="l" value={d.l} step={1} onChange={(v) => update(id, { l: v })} />
+      <ExpressionInput label="starts" value={d.starts} step={1} onChange={(v) => update(id, { starts: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/ChamferEdgeMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/ChamferEdgeMaskNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2ChamferEdgeMaskData } from '../../types/rounding'
+
+export function ChamferEdgeMaskNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2ChamferEdgeMaskData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="chamfer_edge_mask" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/CornerMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/CornerMaskNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2CornerMaskData } from '../../types/rounding'
+
+export function CornerMaskNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2CornerMaskData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="corner_mask" selected={selected}>
+      <TextInput label="corners" value={d.corners} onChange={(v) => update(id, { corners: v })} />
+      <TextInput label="except" value={d.except} onChange={(v) => update(id, { except: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/EdgeMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/EdgeMaskNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2EdgeMaskData } from '../../types/rounding'
+
+export function EdgeMaskNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2EdgeMaskData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="edge_mask" selected={selected}>
+      <TextInput label="edges" value={d.edges} onChange={(v) => update(id, { edges: v })} />
+      <TextInput label="except" value={d.except} onChange={(v) => update(id, { except: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2LinearSweepData } from '../../types/rounding'
+
+export function LinearSweepNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2LinearSweepData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="linear_sweep" selected={selected}>
+      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} onChange={(v) => update(id, { twist: v })} />
+      <ExpressionInput label="scale" value={d.scale} step={0.1} onChange={(v) => update(id, { scale: v })} />
+      <ExpressionInput label="slices" value={d.slices} step={1} onChange={(v) => update(id, { slices: v })} />
+      <CheckboxInput label="center" value={d.center} onChange={(v) => update(id, { center: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2OffsetSweepData } from '../../types/rounding'
+
+export function OffsetSweepNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2OffsetSweepData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="offset_sweep" selected={selected}>
+      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="top_r" value={d.top_r} step={0.5} onChange={(v) => update(id, { top_r: v })} />
+      <ExpressionInput label="bot_r" value={d.bot_r} step={0.5} onChange={(v) => update(id, { bot_r: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PathSweepData } from '../../types/rounding'
+
+export function PathSweepNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PathSweepData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="path_sweep" selected={selected}>
+      <SelectInput label="method" value={d.method} options={["incremental", "manual", "natural"]} onChange={(v) => update(id, { method: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} onChange={(v) => update(id, { twist: v })} />
+      <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RotateSweepData } from '../../types/rounding'
+
+export function RotateSweepNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RotateSweepData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="rotate_sweep" selected={selected}>
+      <ExpressionInput label="angle" value={d.angle} step={1} onChange={(v) => update(id, { angle: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RoundedPrismData } from '../../types/rounding'
+
+export function RoundedPrismNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RoundedPrismData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="rounded_prism" selected={selected}>
+      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="joint_top" value={d.joint_top} step={0.5} onChange={(v) => update(id, { joint_top: v })} />
+      <ExpressionInput label="joint_bot" value={d.joint_bot} step={0.5} onChange={(v) => update(id, { joint_bot: v })} />
+      <ExpressionInput label="joint_sides" value={d.joint_sides} step={0.5} onChange={(v) => update(id, { joint_sides: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/RoundingEdgeMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RoundingEdgeMaskNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RoundingEdgeMaskData } from '../../types/rounding'
+
+export function RoundingEdgeMaskNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RoundingEdgeMaskData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="rounding_edge_mask" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={0.5} onChange={(v) => update(id, { r: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/SkinNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/SkinNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SkinData } from '../../types/rounding'
+
+export function SkinNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SkinData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="skin" selected={selected}>
+      <ExpressionInput label="slices" value={d.slices} step={1} onChange={(v) => update(id, { slices: v })} />
+      <SelectInput label="method" value={d.method} options={["reindex", "distance", "fast_distance", "tangent"]} onChange={(v) => update(id, { method: v })} />
+      <SelectInput label="style" value={d.style} options={["min_edge", "quincunx", "alt_tri", "tri"]} onChange={(v) => update(id, { style: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SpiralSweepData } from '../../types/rounding'
+
+export function SpiralSweepNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SpiralSweepData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="spiral_sweep" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="turns" value={d.turns} step={1} onChange={(v) => update(id, { turns: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2StrokeData } from '../../types/rounding'
+
+export function StrokeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2StrokeData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_rounding" label="stroke" selected={selected}>
+      <ExpressionInput label="width" value={d.width} step={0.5} onChange={(v) => update(id, { width: v })} />
+      <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
+      <SelectInput label="endcaps" value={d.endcaps} options={["butt", "round", "square", "line", "tail"]} onChange={(v) => update(id, { endcaps: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/EllipseNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/EllipseNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2EllipseData } from '../../types/shapes2d'
+
+export function EllipseNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2EllipseData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="ellipse" selected={selected}>
+      <ExpressionInput label="rx" value={d.rx} step={1} onChange={(v) => update(id, { rx: v })} />
+      <ExpressionInput label="ry" value={d.ry} step={1} onChange={(v) => update(id, { ry: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/HexagonNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/HexagonNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2HexagonData } from '../../types/shapes2d'
+
+export function HexagonNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2HexagonData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="hexagon" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/OctagonNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/OctagonNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2OctagonData } from '../../types/shapes2d'
+
+export function OctagonNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2OctagonData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="octagon" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/PentagonNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/PentagonNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PentagonData } from '../../types/shapes2d'
+
+export function PentagonNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PentagonData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="pentagon" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/RectNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/RectNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RectData } from '../../types/shapes2d'
+
+export function RectNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RectData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="rect" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/RegularNgonNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/RegularNgonNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RegularNgonData } from '../../types/shapes2d'
+
+export function RegularNgonNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RegularNgonData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="regular_ngon" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/RightTriangleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/RightTriangleNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RightTriangleData } from '../../types/shapes2d'
+
+export function RightTriangleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RightTriangleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="right_triangle" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/RingNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/RingNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RingData } from '../../types/shapes2d'
+
+export function RingNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RingData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="ring" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="r1" value={d.r1} step={1} onChange={(v) => update(id, { r1: v })} />
+      <ExpressionInput label="r2" value={d.r2} step={1} onChange={(v) => update(id, { r2: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/SquircleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/SquircleNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SquircleData } from '../../types/shapes2d'
+
+export function SquircleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SquircleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="squircle" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="squareness" value={d.squareness} step={0.1} onChange={(v) => update(id, { squareness: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/StarNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/StarNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2StarData } from '../../types/shapes2d'
+
+export function StarNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2StarData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="star" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ir" value={d.ir} step={1} onChange={(v) => update(id, { ir: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/Teardrop2dNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/Teardrop2dNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2Teardrop2dData } from '../../types/shapes2d'
+
+export function Teardrop2dNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2Teardrop2dData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="teardrop2d" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={1} onChange={(v) => update(id, { ang: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes2d/TrapezoidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes2d/TrapezoidNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2TrapezoidData } from '../../types/shapes2d'
+
+export function TrapezoidNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2TrapezoidData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes2d" label="trapezoid" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="w1" value={d.w1} step={1} onChange={(v) => update(id, { w1: v })} />
+      <ExpressionInput label="w2" value={d.w2} step={1} onChange={(v) => update(id, { w2: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/CuboidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/CuboidNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2CuboidData } from '../../types/shapes3d'
+
+export function CuboidNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2CuboidData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="cuboid" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/CylNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/CylNode.tsx
@@ -1,0 +1,20 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2CylData } from '../../types/shapes3d'
+
+export function CylNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2CylData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="cyl" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="r1" value={d.r1} step={1} onChange={(v) => update(id, { r1: v })} />
+      <ExpressionInput label="r2" value={d.r2} step={1} onChange={(v) => update(id, { r2: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+      <CheckboxInput label="circum" value={d.circum} onChange={(v) => update(id, { circum: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/FilletNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/FilletNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2FilletData } from '../../types/shapes3d'
+
+export function FilletNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2FilletData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="fillet" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={0.5} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/OctahedronNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/OctahedronNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2OctahedronData } from '../../types/shapes3d'
+
+export function OctahedronNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2OctahedronData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="octahedron" selected={selected}>
+      <ExpressionInput label="size" value={d.size} step={1} onChange={(v) => update(id, { size: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/OnionNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/OnionNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2OnionData } from '../../types/shapes3d'
+
+export function OnionNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2OnionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="onion" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} onChange={(v) => update(id, { cap_h: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/PieSliceNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/PieSliceNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PieSliceData } from '../../types/shapes3d'
+
+export function PieSliceNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PieSliceData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="pie_slice" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/PrismoidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/PrismoidNode.tsx
@@ -1,0 +1,22 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2PrismoidData } from '../../types/shapes3d'
+
+export function PrismoidNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2PrismoidData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="prismoid" selected={selected}>
+      <ExpressionInput label="size1_x" value={d.size1_x} step={1} onChange={(v) => update(id, { size1_x: v })} />
+      <ExpressionInput label="size1_y" value={d.size1_y} step={1} onChange={(v) => update(id, { size1_y: v })} />
+      <ExpressionInput label="size2_x" value={d.size2_x} step={1} onChange={(v) => update(id, { size2_x: v })} />
+      <ExpressionInput label="size2_y" value={d.size2_y} step={1} onChange={(v) => update(id, { size2_y: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="shift_x" value={d.shift_x} step={1} onChange={(v) => update(id, { shift_x: v })} />
+      <ExpressionInput label="shift_y" value={d.shift_y} step={1} onChange={(v) => update(id, { shift_y: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/RectTubeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/RectTubeNode.tsx
@@ -1,0 +1,20 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RectTubeData } from '../../types/shapes3d'
+
+export function RectTubeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RectTubeData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="rect_tube" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="size_x" value={d.size_x} step={1} onChange={(v) => update(id, { size_x: v })} />
+      <ExpressionInput label="size_y" value={d.size_y} step={1} onChange={(v) => update(id, { size_y: v })} />
+      <ExpressionInput label="isize_x" value={d.isize_x} step={1} onChange={(v) => update(id, { isize_x: v })} />
+      <ExpressionInput label="isize_y" value={d.isize_y} step={1} onChange={(v) => update(id, { isize_y: v })} />
+      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/RegularPrismNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/RegularPrismNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RegularPrismData } from '../../types/shapes3d'
+
+export function RegularPrismNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RegularPrismData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="regular_prism" selected={selected}>
+      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/SpheroidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/SpheroidNode.tsx
@@ -1,0 +1,18 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, CheckboxInput, SelectInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SpheroidData } from '../../types/shapes3d'
+
+const STYLE_OPTIONS = ['aligned', 'stagger', 'octa', 'icosa']
+
+export function SpheroidNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SpheroidData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="spheroid" selected={selected}>
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <SelectInput label="style" value={d.style} options={STYLE_OPTIONS} onChange={(v) => update(id, { style: v })} />
+      <CheckboxInput label="circum" value={d.circum} onChange={(v) => update(id, { circum: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/TeardropNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TeardropNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2TeardropData } from '../../types/shapes3d'
+
+export function TeardropNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2TeardropData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="teardrop" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} onChange={(v) => update(id, { cap_h: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/Text3dNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/Text3dNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput, TextInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2Text3dData } from '../../types/shapes3d'
+
+export function Text3dNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2Text3dData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="text3d" selected={selected}>
+      <TextInput label="text" value={d.text} onChange={(v) => update(id, { text: v })} />
+      <ExpressionInput label="h" value={d.h} step={0.5} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="size" value={d.size} step={1} onChange={(v) => update(id, { size: v })} />
+      <TextInput label="font" value={d.font} onChange={(v) => update(id, { font: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/TorusNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TorusNode.tsx
@@ -1,0 +1,15 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2TorusData } from '../../types/shapes3d'
+
+export function TorusNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2TorusData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="torus" selected={selected}>
+      <ExpressionInput label="r_maj" value={d.r_maj} step={1} onChange={(v) => update(id, { r_maj: v })} />
+      <ExpressionInput label="r_min" value={d.r_min} step={0.5} onChange={(v) => update(id, { r_min: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/TubeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TubeNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2TubeData } from '../../types/shapes3d'
+
+export function TubeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2TubeData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="tube" selected={selected}>
+      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="or" value={d.or} step={1} onChange={(v) => update(id, { or: v })} />
+      <ExpressionInput label="ir" value={d.ir} step={1} onChange={(v) => update(id, { ir: v })} />
+      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/shapes3d/WedgeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/WedgeNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2WedgeData } from '../../types/shapes3d'
+
+export function WedgeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2WedgeData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_shapes3d" label="wedge" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/BackNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/BackNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function BackNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="back" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/DownNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/DownNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function DownNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="down" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/FwdNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/FwdNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function FwdNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="fwd" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/LeftNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/LeftNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function LeftNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="left" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/MoveNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/MoveNode.tsx
@@ -1,0 +1,16 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2MoveData } from '../../types/transforms'
+
+export function MoveNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2MoveData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="move" selected={selected}>
+      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/RightNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/RightNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function RightNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="right" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/RotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/RotNode.tsx
@@ -1,0 +1,17 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2RotData } from '../../types/transforms'
+
+export function RotNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2RotData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="rot" selected={selected}>
+      <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
+      <ExpressionInput label="vx" value={d.vx} step={1} onChange={(v) => update(id, { vx: v })} />
+      <ExpressionInput label="vy" value={d.vy} step={1} onChange={(v) => update(id, { vy: v })} />
+      <ExpressionInput label="vz" value={d.vz} step={1} onChange={(v) => update(id, { vz: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/SkewNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/SkewNode.tsx
@@ -1,0 +1,19 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2SkewData } from '../../types/transforms'
+
+export function SkewNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2SkewData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="skew" selected={selected}>
+      <ExpressionInput label="sxy" value={d.sxy} step={0.1} onChange={(v) => update(id, { sxy: v })} />
+      <ExpressionInput label="sxz" value={d.sxz} step={0.1} onChange={(v) => update(id, { sxz: v })} />
+      <ExpressionInput label="syx" value={d.syx} step={0.1} onChange={(v) => update(id, { syx: v })} />
+      <ExpressionInput label="syz" value={d.syz} step={0.1} onChange={(v) => update(id, { syz: v })} />
+      <ExpressionInput label="szx" value={d.szx} step={0.1} onChange={(v) => update(id, { szx: v })} />
+      <ExpressionInput label="szy" value={d.szy} step={0.1} onChange={(v) => update(id, { szy: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/UpNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/UpNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2DirectionData } from '../../types/transforms'
+
+export function UpNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2DirectionData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="up" selected={selected}>
+      <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/XflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XflipNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisFlipData } from '../../types/transforms'
+
+export function XflipNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisFlipData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="xflip" selected={selected}>
+      <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/XrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XrotNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisRotData } from '../../types/transforms'
+
+export function XrotNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisRotData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="xrot" selected={selected}>
+      <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/XscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XscaleNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisScaleData } from '../../types/transforms'
+
+export function XscaleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisScaleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="xscale" selected={selected}>
+      <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/YflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YflipNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisFlipData } from '../../types/transforms'
+
+export function YflipNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisFlipData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="yflip" selected={selected}>
+      <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/YrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YrotNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisRotData } from '../../types/transforms'
+
+export function YrotNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisRotData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="yrot" selected={selected}>
+      <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/YscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YscaleNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisScaleData } from '../../types/transforms'
+
+export function YscaleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisScaleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="yscale" selected={selected}>
+      <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/ZflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZflipNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisFlipData } from '../../types/transforms'
+
+export function ZflipNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisFlipData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="zflip" selected={selected}>
+      <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/ZrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZrotNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisRotData } from '../../types/transforms'
+
+export function ZrotNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisRotData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="zrot" selected={selected}>
+      <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/nodes/transforms/ZscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZscaleNode.tsx
@@ -1,0 +1,14 @@
+import { type NodeProps } from '@xyflow/react'
+import { BaseNode, ExpressionInput } from '@/nodes/BaseNode'
+import { useEditorStore } from '@/store/editorStore'
+import type { Bosl2AxisScaleData } from '../../types/transforms'
+
+export function ZscaleNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as Bosl2AxisScaleData
+  const update = useEditorStore((s) => s.updateNodeData)
+  return (
+    <BaseNode id={id} category="bosl2_transforms" label="zscale" selected={selected}>
+      <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
+    </BaseNode>
+  )
+}

--- a/src/nodepacks/bosl2/palette/attachmentsPalette.ts
+++ b/src/nodepacks/bosl2/palette/attachmentsPalette.ts
@@ -1,0 +1,52 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const ATTACHMENTS_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_diff', label: 'diff', category: 'bosl2_attachments',
+    defaultData: { remove: 'remove', keep: '' },
+    description: 'BOSL2 diff() — boolean difference using attachment tags.',
+    inputs: 'remove — tag to subtract; keep — tag to keep',
+  },
+  {
+    type: 'bosl2_intersect', label: 'intersect', category: 'bosl2_attachments',
+    defaultData: { intersect: 'intersect', keep: '' },
+    description: 'BOSL2 intersect() — boolean intersection using attachment tags.',
+    inputs: 'intersect — tag to intersect; keep — tag to keep',
+  },
+  {
+    type: 'bosl2_position', label: 'position', category: 'bosl2_attachments',
+    defaultData: { at: 'TOP' },
+    description: 'BOSL2 position() — place a child at a named anchor of the parent.',
+    inputs: 'at — anchor name (e.g. TOP, BOTTOM, LEFT, RIGHT, FRONT, BACK)',
+  },
+  {
+    type: 'bosl2_attach', label: 'attach', category: 'bosl2_attachments',
+    defaultData: { parent: 'TOP', child: 'BOT', overlap: 0 },
+    description: 'BOSL2 attach() — attach a child anchor to a parent anchor.',
+    inputs: 'parent — parent anchor; child — child anchor; overlap',
+  },
+  {
+    type: 'bosl2_tag', label: 'tag', category: 'bosl2_attachments',
+    defaultData: { tag: 'remove' },
+    description: 'BOSL2 tag() — tag children for use with diff()/intersect().',
+    inputs: 'tag — tag name string',
+  },
+  {
+    type: 'bosl2_recolor', label: 'recolor', category: 'bosl2_attachments',
+    defaultData: { c: 'red' },
+    description: 'BOSL2 recolor() — set the color of children.',
+    inputs: 'c — color name or [r,g,b] expression',
+  },
+  {
+    type: 'bosl2_half_of', label: 'half_of', category: 'bosl2_attachments',
+    defaultData: { vx: 0, vy: 0, vz: 1, cpx: 0, cpy: 0, cpz: 0 },
+    description: 'BOSL2 half_of() — cut children in half along a plane.',
+    inputs: 'vx, vy, vz — plane normal; cpx, cpy, cpz — center point',
+  },
+  {
+    type: 'bosl2_partition', label: 'partition', category: 'bosl2_attachments',
+    defaultData: { x: 100, y: 100, z: 100, spread: 10, cutpath: 'jigsaw' },
+    description: 'BOSL2 partition() — split an object into interlocking pieces.',
+    inputs: 'x, y, z — size; spread; cutpath — cut pattern',
+  },
+]

--- a/src/nodepacks/bosl2/palette/mechanicalPalette.ts
+++ b/src/nodepacks/bosl2/palette/mechanicalPalette.ts
@@ -1,0 +1,94 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const MECHANICAL_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_spur_gear', label: 'spur_gear', category: 'bosl2_mechanical',
+    defaultData: { mod: 2, teeth: 20, thickness: 5, pressure_angle: 20, helical: 0, shaft_diam: 5, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 spur gear.',
+    inputs: 'mod — module; teeth; thickness; pressure_angle; helical; shaft_diam',
+  },
+  {
+    type: 'bosl2_rack', label: 'rack', category: 'bosl2_mechanical',
+    defaultData: { mod: 2, teeth: 10, thickness: 5, pressure_angle: 20, helical: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 gear rack (linear gear).',
+    inputs: 'mod — module; teeth; thickness; pressure_angle; helical',
+  },
+  {
+    type: 'bosl2_bevel_gear', label: 'bevel_gear', category: 'bosl2_mechanical',
+    defaultData: { mod: 2, teeth: 20, mate_teeth: 20, shaft_angle: 90, face_width: 10, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 bevel gear for intersecting shaft axes.',
+    inputs: 'mod; teeth; mate_teeth; shaft_angle; face_width',
+  },
+  {
+    type: 'bosl2_worm', label: 'worm', category: 'bosl2_mechanical',
+    defaultData: { mod: 2, d: 20, l: 30, starts: 1, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 worm gear screw.',
+    inputs: 'mod — module; d — diameter; l — length; starts',
+  },
+  {
+    type: 'bosl2_worm_gear', label: 'worm_gear', category: 'bosl2_mechanical',
+    defaultData: { mod: 2, teeth: 30, worm_diam: 20, worm_starts: 1, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 worm gear wheel.',
+    inputs: 'mod; teeth; worm_diam; worm_starts',
+  },
+  {
+    type: 'bosl2_threaded_rod', label: 'threaded_rod', category: 'bosl2_mechanical',
+    defaultData: { d: 10, l: 30, pitch: 2, internal: false, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 threaded rod (UTS/ISO threading).',
+    inputs: 'd — diameter; l — length; pitch; internal',
+  },
+  {
+    type: 'bosl2_threaded_nut', label: 'threaded_nut', category: 'bosl2_mechanical',
+    defaultData: { nutwidth: 17, id: 10, h: 8, pitch: 2, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 threaded nut.',
+    inputs: 'nutwidth — outer width; id — inner diameter; h — height; pitch',
+  },
+  {
+    type: 'bosl2_screw', label: 'screw', category: 'bosl2_mechanical',
+    defaultData: { spec: 'M3', head: 'socket', drive: 'hex', length: 12, thread_len: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 screw — parametric screw by spec string.',
+    inputs: 'spec — e.g. "M3"; head; drive; length; thread_len',
+  },
+  {
+    type: 'bosl2_screw_hole', label: 'screw_hole', category: 'bosl2_mechanical',
+    defaultData: { spec: 'M3', head: 'socket', length: 12, oversize: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 screw_hole — clearance hole for a screw.',
+    inputs: 'spec; head; length; oversize',
+  },
+  {
+    type: 'bosl2_nut', label: 'nut', category: 'bosl2_mechanical',
+    defaultData: { spec: 'M3', shape: 'hex', thickness: 2.4, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 nut — parametric nut by spec string.',
+    inputs: 'spec; shape — hex or square; thickness',
+  },
+  {
+    type: 'bosl2_dovetail', label: 'dovetail', category: 'bosl2_mechanical',
+    defaultData: { gender: 'male', width: 10, height: 5, slope: 6, slide: 20, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 dovetail joint.',
+    inputs: 'gender — male/female; width; height; slope; slide',
+  },
+  {
+    type: 'bosl2_snap_pin', label: 'snap_pin', category: 'bosl2_mechanical',
+    defaultData: { r: 1.5, l: 10, nub_depth: 0.4, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 snap pin for snap-fit joints.',
+    inputs: 'r — pin radius; l — length; nub_depth',
+  },
+  {
+    type: 'bosl2_knuckle_hinge', label: 'knuckle_hinge', category: 'bosl2_mechanical',
+    defaultData: { length: 30, offset: 5, segs: 4, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 knuckle hinge.',
+    inputs: 'length; offset; segs — knuckle segments',
+  },
+  {
+    type: 'bosl2_bottle_neck', label: 'bottle_neck', category: 'bosl2_mechanical',
+    defaultData: { wall: 2, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 generic bottle neck threading.',
+    inputs: 'wall — wall thickness',
+  },
+  {
+    type: 'bosl2_bottle_cap', label: 'bottle_cap', category: 'bosl2_mechanical',
+    defaultData: { wall: 2, texture: 'pointed', anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 generic bottle cap.',
+    inputs: 'wall — thickness; texture — grip pattern',
+  },
+]

--- a/src/nodepacks/bosl2/palette/roundingPalette.ts
+++ b/src/nodepacks/bosl2/palette/roundingPalette.ts
@@ -1,0 +1,76 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const ROUNDING_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_offset_sweep', label: 'offset_sweep', category: 'bosl2_rounding',
+    defaultData: { height: 10, top_r: 1, bot_r: 1, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 offset_sweep() — sweep a 2D path upward with offset profiles.',
+    inputs: 'height; top_r, bot_r — rounding radii at top/bottom',
+  },
+  {
+    type: 'bosl2_rounded_prism', label: 'rounded_prism', category: 'bosl2_rounding',
+    defaultData: { height: 10, joint_top: 1, joint_bot: 1, joint_sides: 1, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 rounded_prism() — prism with continuous curvature rounding.',
+    inputs: 'height; joint_top, joint_bot, joint_sides — joint radii',
+  },
+  {
+    type: 'bosl2_skin', label: 'skin', category: 'bosl2_rounding',
+    defaultData: { slices: 10, method: 'reindex', style: 'min_edge' },
+    description: 'BOSL2 skin() — create a solid between a list of profiles.',
+    inputs: 'slices; method — vertex matching; style — triangulation',
+  },
+  {
+    type: 'bosl2_linear_sweep', label: 'linear_sweep', category: 'bosl2_rounding',
+    defaultData: { height: 10, twist: 0, scale: 1, slices: 0, center: false, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 linear_sweep() — enhanced linear extrusion with twist and scale.',
+    inputs: 'height; twist — degrees; scale; slices; center',
+  },
+  {
+    type: 'bosl2_rotate_sweep', label: 'rotate_sweep', category: 'bosl2_rounding',
+    defaultData: { angle: 360, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 rotate_sweep() — enhanced rotational extrusion.',
+    inputs: 'angle — sweep angle in degrees',
+  },
+  {
+    type: 'bosl2_path_sweep', label: 'path_sweep', category: 'bosl2_rounding',
+    defaultData: { method: 'incremental', twist: 0, closed: false, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 path_sweep() — sweep a 2D shape along a 3D path.',
+    inputs: 'method; twist; closed',
+  },
+  {
+    type: 'bosl2_spiral_sweep', label: 'spiral_sweep', category: 'bosl2_rounding',
+    defaultData: { h: 20, r: 10, turns: 3, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 spiral_sweep() — sweep a profile in a spiral/helix.',
+    inputs: 'h — height; r — radius; turns — number of revolutions',
+  },
+  {
+    type: 'bosl2_edge_mask', label: 'edge_mask', category: 'bosl2_rounding',
+    defaultData: { edges: 'ALL', except: '' },
+    description: 'BOSL2 edge_mask() — apply a mask to selected edges of a parent shape.',
+    inputs: 'edges — edge selection; except — edges to skip',
+  },
+  {
+    type: 'bosl2_corner_mask', label: 'corner_mask', category: 'bosl2_rounding',
+    defaultData: { corners: 'ALL', except: '' },
+    description: 'BOSL2 corner_mask() — apply a mask to selected corners of a parent shape.',
+    inputs: 'corners — corner selection; except — corners to skip',
+  },
+  {
+    type: 'bosl2_rounding_edge_mask', label: 'rounding_edge_mask', category: 'bosl2_rounding',
+    defaultData: { h: 10, r: 2, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 rounding_edge_mask() — mask for rounding edges.',
+    inputs: 'h — length; r — rounding radius',
+  },
+  {
+    type: 'bosl2_chamfer_edge_mask', label: 'chamfer_edge_mask', category: 'bosl2_rounding',
+    defaultData: { h: 10, chamfer: 2, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 chamfer_edge_mask() — mask for chamfering edges.',
+    inputs: 'h — length; chamfer — chamfer size',
+  },
+  {
+    type: 'bosl2_stroke', label: 'stroke', category: 'bosl2_rounding',
+    defaultData: { width: 1, closed: false, endcaps: 'butt' },
+    description: 'BOSL2 stroke() — draw a path as a 3D stroke with width.',
+    inputs: 'width; closed; endcaps — end cap style',
+  },
+]

--- a/src/nodepacks/bosl2/palette/shapes2dPalette.ts
+++ b/src/nodepacks/bosl2/palette/shapes2dPalette.ts
@@ -1,0 +1,76 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const SHAPES2D_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_rect', label: 'rect', category: 'bosl2_shapes2d',
+    defaultData: { x: 20, y: 10, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 enhanced rectangle with optional rounding and chamfer.',
+    inputs: 'x, y — dimensions; rounding, chamfer',
+  },
+  {
+    type: 'bosl2_ellipse', label: 'ellipse', category: 'bosl2_shapes2d',
+    defaultData: { rx: 10, ry: 5, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 ellipse.',
+    inputs: 'rx, ry — semi-axis radii',
+  },
+  {
+    type: 'bosl2_regular_ngon', label: 'regular_ngon', category: 'bosl2_shapes2d',
+    defaultData: { n: 6, r: 10, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 regular N-sided polygon.',
+    inputs: 'n — number of sides; r — radius',
+  },
+  {
+    type: 'bosl2_pentagon', label: 'pentagon', category: 'bosl2_shapes2d',
+    defaultData: { r: 10, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 regular pentagon.',
+    inputs: 'r — radius',
+  },
+  {
+    type: 'bosl2_hexagon', label: 'hexagon', category: 'bosl2_shapes2d',
+    defaultData: { r: 10, rounding: 0, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 regular hexagon with optional rounding.',
+    inputs: 'r — radius; rounding',
+  },
+  {
+    type: 'bosl2_octagon', label: 'octagon', category: 'bosl2_shapes2d',
+    defaultData: { r: 10, rounding: 0, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 regular octagon with optional rounding.',
+    inputs: 'r — radius; rounding',
+  },
+  {
+    type: 'bosl2_star', label: 'star', category: 'bosl2_shapes2d',
+    defaultData: { n: 5, r: 10, ir: 5, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 star shape.',
+    inputs: 'n — points; r — outer radius; ir — inner radius',
+  },
+  {
+    type: 'bosl2_trapezoid', label: 'trapezoid', category: 'bosl2_shapes2d',
+    defaultData: { h: 10, w1: 20, w2: 10, rounding: 0, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 trapezoid shape.',
+    inputs: 'h — height; w1 — bottom width; w2 — top width; rounding',
+  },
+  {
+    type: 'bosl2_right_triangle', label: 'right_triangle', category: 'bosl2_shapes2d',
+    defaultData: { x: 10, y: 10, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 right triangle.',
+    inputs: 'x, y — leg lengths',
+  },
+  {
+    type: 'bosl2_teardrop2d', label: 'teardrop2d', category: 'bosl2_shapes2d',
+    defaultData: { r: 10, ang: 45, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 2D teardrop for printable holes.',
+    inputs: 'r — radius; ang — angle',
+  },
+  {
+    type: 'bosl2_squircle', label: 'squircle', category: 'bosl2_shapes2d',
+    defaultData: { x: 20, y: 20, squareness: 0.5, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 squircle (rounded square) shape.',
+    inputs: 'x, y — dimensions; squareness — 0=circle, 1=square',
+  },
+  {
+    type: 'bosl2_ring', label: 'ring', category: 'bosl2_shapes2d',
+    defaultData: { n: 36, r1: 10, r2: 8, anchor: 'CENTER', spin: 0 },
+    description: 'BOSL2 2D ring (annulus).',
+    inputs: 'n — segments; r1 — outer radius; r2 — inner radius',
+  },
+]

--- a/src/nodepacks/bosl2/palette/shapes3dPalette.ts
+++ b/src/nodepacks/bosl2/palette/shapes3dPalette.ts
@@ -1,0 +1,94 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const SHAPES3D_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_cuboid', label: 'cuboid', category: 'bosl2_shapes3d',
+    defaultData: { x: 10, y: 10, z: 10, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 enhanced cube with optional rounding and chamfering on edges.',
+    inputs: 'x, y, z — size; rounding — edge radius; chamfer — edge bevel',
+  },
+  {
+    type: 'bosl2_cyl', label: 'cyl', category: 'bosl2_shapes3d',
+    defaultData: { h: 10, r: 5, r1: 5, r2: 5, chamfer: 0, rounding: 0, circum: false, fn: 32, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 enhanced cylinder with chamfer and rounding options.',
+    inputs: 'h — height; r — radius; r1/r2 — bottom/top radii; chamfer, rounding',
+  },
+  {
+    type: 'bosl2_spheroid', label: 'spheroid', category: 'bosl2_shapes3d',
+    defaultData: { r: 10, style: 'aligned', circum: false, fn: 32, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 enhanced sphere with multiple tessellation styles.',
+    inputs: 'r — radius; style — tessellation style',
+  },
+  {
+    type: 'bosl2_torus', label: 'torus', category: 'bosl2_shapes3d',
+    defaultData: { r_maj: 20, r_min: 5, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 torus (donut shape).',
+    inputs: 'r_maj — major radius; r_min — minor (tube) radius',
+  },
+  {
+    type: 'bosl2_tube', label: 'tube', category: 'bosl2_shapes3d',
+    defaultData: { h: 20, or: 10, ir: 8, wall: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 hollow tube with inner/outer radius.',
+    inputs: 'h — height; or — outer radius; ir — inner radius; wall — wall thickness',
+  },
+  {
+    type: 'bosl2_prismoid', label: 'prismoid', category: 'bosl2_shapes3d',
+    defaultData: { size1_x: 20, size1_y: 20, size2_x: 10, size2_y: 10, h: 15, shift_x: 0, shift_y: 0, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 prismoid — a truncated pyramid with rectangular bases.',
+    inputs: 'size1 — bottom; size2 — top; h — height; shift — top offset',
+  },
+  {
+    type: 'bosl2_wedge', label: 'wedge', category: 'bosl2_shapes3d',
+    defaultData: { x: 10, y: 10, z: 10, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 right-angle wedge.',
+    inputs: 'x, y, z — bounding box dimensions',
+  },
+  {
+    type: 'bosl2_pie_slice', label: 'pie_slice', category: 'bosl2_shapes3d',
+    defaultData: { h: 10, r: 10, ang: 90, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 pie/wedge slice of a cylinder.',
+    inputs: 'h — height; r — radius; ang — sweep angle',
+  },
+  {
+    type: 'bosl2_teardrop', label: 'teardrop', category: 'bosl2_shapes3d',
+    defaultData: { h: 10, r: 5, ang: 45, cap_h: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 teardrop shape for 3D printing overhang-friendly holes.',
+    inputs: 'h — height; r — radius; ang — teardrop angle; cap_h — cap height',
+  },
+  {
+    type: 'bosl2_onion', label: 'onion', category: 'bosl2_shapes3d',
+    defaultData: { r: 10, ang: 45, cap_h: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 onion (teardrop-rotated) shape.',
+    inputs: 'r — radius; ang — angle; cap_h — cap height',
+  },
+  {
+    type: 'bosl2_rect_tube', label: 'rect_tube', category: 'bosl2_shapes3d',
+    defaultData: { h: 20, size_x: 20, size_y: 20, isize_x: 16, isize_y: 16, wall: 0, rounding: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 rectangular tube with optional rounding.',
+    inputs: 'h — height; size — outer dims; isize — inner dims; wall, rounding',
+  },
+  {
+    type: 'bosl2_octahedron', label: 'octahedron', category: 'bosl2_shapes3d',
+    defaultData: { size: 20, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 regular octahedron.',
+    inputs: 'size — overall size',
+  },
+  {
+    type: 'bosl2_regular_prism', label: 'regular_prism', category: 'bosl2_shapes3d',
+    defaultData: { n: 6, h: 10, r: 5, rounding: 0, chamfer: 0, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 regular prism (n-sided) with optional rounding and chamfer.',
+    inputs: 'n — sides; h — height; r — radius; rounding, chamfer',
+  },
+  {
+    type: 'bosl2_text3d', label: 'text3d', category: 'bosl2_shapes3d',
+    defaultData: { text: 'Hello', h: 2, size: 10, font: 'Liberation Sans', anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 3D extruded text.',
+    inputs: 'text — string; h — extrusion height; size — font size; font — font name',
+  },
+  {
+    type: 'bosl2_fillet', label: 'fillet', category: 'bosl2_shapes3d',
+    defaultData: { h: 10, r: 3, ang: 90, anchor: 'CENTER', spin: 0, orient: 'UP' },
+    description: 'BOSL2 fillet (concave rounding) mask for edges.',
+    inputs: 'h — height; r — fillet radius; ang — angle',
+  },
+]

--- a/src/nodepacks/bosl2/palette/transformsPalette.ts
+++ b/src/nodepacks/bosl2/palette/transformsPalette.ts
@@ -1,0 +1,163 @@
+import type { PaletteItem } from '@/types/nodes'
+
+export const TRANSFORMS_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_move', label: 'move', category: 'bosl2_transforms',
+    defaultData: { x: 0, y: 0, z: 0 },
+    description: 'BOSL2 move() — positional translation shorthand.',
+    inputs: 'x, y, z — translation vector',
+  },
+  {
+    type: 'bosl2_left', label: 'left', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 left() — translate in −X direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_right', label: 'right', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 right() — translate in +X direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_fwd', label: 'fwd', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 fwd() — translate in −Y direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_back', label: 'back', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 back() — translate in +Y direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_up', label: 'up', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 up() — translate in +Z direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_down', label: 'down', category: 'bosl2_transforms',
+    defaultData: { d: 10 },
+    description: 'BOSL2 down() — translate in −Z direction.',
+    inputs: 'd — distance',
+  },
+  {
+    type: 'bosl2_rot', label: 'rot', category: 'bosl2_transforms',
+    defaultData: { a: 0, vx: 0, vy: 0, vz: 0 },
+    description: 'BOSL2 rot() — rotation around an arbitrary axis.',
+    inputs: 'a — angle; vx, vy, vz — rotation axis vector',
+  },
+  {
+    type: 'bosl2_xrot', label: 'xrot', category: 'bosl2_transforms',
+    defaultData: { a: 0 },
+    description: 'BOSL2 xrot() — rotation around the X axis.',
+    inputs: 'a — angle in degrees',
+  },
+  {
+    type: 'bosl2_yrot', label: 'yrot', category: 'bosl2_transforms',
+    defaultData: { a: 0 },
+    description: 'BOSL2 yrot() — rotation around the Y axis.',
+    inputs: 'a — angle in degrees',
+  },
+  {
+    type: 'bosl2_zrot', label: 'zrot', category: 'bosl2_transforms',
+    defaultData: { a: 0 },
+    description: 'BOSL2 zrot() — rotation around the Z axis.',
+    inputs: 'a — angle in degrees',
+  },
+  {
+    type: 'bosl2_xscale', label: 'xscale', category: 'bosl2_transforms',
+    defaultData: { factor: 1 },
+    description: 'BOSL2 xscale() — scale along the X axis.',
+    inputs: 'factor — scale multiplier',
+  },
+  {
+    type: 'bosl2_yscale', label: 'yscale', category: 'bosl2_transforms',
+    defaultData: { factor: 1 },
+    description: 'BOSL2 yscale() — scale along the Y axis.',
+    inputs: 'factor — scale multiplier',
+  },
+  {
+    type: 'bosl2_zscale', label: 'zscale', category: 'bosl2_transforms',
+    defaultData: { factor: 1 },
+    description: 'BOSL2 zscale() — scale along the Z axis.',
+    inputs: 'factor — scale multiplier',
+  },
+  {
+    type: 'bosl2_xflip', label: 'xflip', category: 'bosl2_transforms',
+    defaultData: { offset: 0 },
+    description: 'BOSL2 xflip() — mirror across the YZ plane.',
+    inputs: 'offset — distance from origin',
+  },
+  {
+    type: 'bosl2_yflip', label: 'yflip', category: 'bosl2_transforms',
+    defaultData: { offset: 0 },
+    description: 'BOSL2 yflip() — mirror across the XZ plane.',
+    inputs: 'offset — distance from origin',
+  },
+  {
+    type: 'bosl2_zflip', label: 'zflip', category: 'bosl2_transforms',
+    defaultData: { offset: 0 },
+    description: 'BOSL2 zflip() — mirror across the XY plane.',
+    inputs: 'offset — distance from origin',
+  },
+  {
+    type: 'bosl2_skew', label: 'skew', category: 'bosl2_transforms',
+    defaultData: { sxy: 0, sxz: 0, syx: 0, syz: 0, szx: 0, szy: 0 },
+    description: 'BOSL2 skew() — shear transformation.',
+    inputs: 'sxy, sxz, syx, syz, szx, szy — shear coefficients',
+  },
+]
+
+export const DISTRIBUTORS_PALETTE: PaletteItem[] = [
+  {
+    type: 'bosl2_xcopies', label: 'xcopies', category: 'bosl2_distributors',
+    defaultData: { spacing: 10, n: 3 },
+    description: 'BOSL2 xcopies() — distribute copies along the X axis.',
+    inputs: 'spacing — distance between copies; n — count',
+  },
+  {
+    type: 'bosl2_ycopies', label: 'ycopies', category: 'bosl2_distributors',
+    defaultData: { spacing: 10, n: 3 },
+    description: 'BOSL2 ycopies() — distribute copies along the Y axis.',
+    inputs: 'spacing — distance between copies; n — count',
+  },
+  {
+    type: 'bosl2_zcopies', label: 'zcopies', category: 'bosl2_distributors',
+    defaultData: { spacing: 10, n: 3 },
+    description: 'BOSL2 zcopies() — distribute copies along the Z axis.',
+    inputs: 'spacing — distance between copies; n — count',
+  },
+  {
+    type: 'bosl2_grid_copies', label: 'grid_copies', category: 'bosl2_distributors',
+    defaultData: { spacing_x: 10, spacing_y: 10, n_x: 3, n_y: 3, stagger: false },
+    description: 'BOSL2 grid_copies() — 2D grid of copies.',
+    inputs: 'spacing_x/y — grid spacing; n_x/y — counts; stagger — hex stagger',
+  },
+  {
+    type: 'bosl2_rot_copies', label: 'rot_copies', category: 'bosl2_distributors',
+    defaultData: { n: 6, sa: 0 },
+    description: 'BOSL2 rot_copies() — rotational array of copies.',
+    inputs: 'n — count; sa — start angle',
+  },
+  {
+    type: 'bosl2_arc_copies', label: 'arc_copies', category: 'bosl2_distributors',
+    defaultData: { n: 6, r: 20, sa: 0, ea: 360 },
+    description: 'BOSL2 arc_copies() — copies distributed along an arc.',
+    inputs: 'n — count; r — radius; sa — start angle; ea — end angle',
+  },
+  {
+    type: 'bosl2_mirror_copy', label: 'mirror_copy', category: 'bosl2_distributors',
+    defaultData: { vx: 1, vy: 0, vz: 0, offset: 0 },
+    description: 'BOSL2 mirror_copy() — copy and mirror across a plane.',
+    inputs: 'vx, vy, vz — mirror plane normal; offset',
+  },
+  {
+    type: 'bosl2_path_copies', label: 'path_copies', category: 'bosl2_distributors',
+    defaultData: { path: '[]', n: 0, closed: false },
+    description: 'BOSL2 path_copies() — distribute copies along a path.',
+    inputs: 'path — point array; n — count; closed',
+  },
+]

--- a/src/nodepacks/bosl2/preamble.ts
+++ b/src/nodepacks/bosl2/preamble.ts
@@ -1,0 +1,51 @@
+import type { Node } from '@xyflow/react'
+
+// ─── BOSL2 includes ───────────────────────────────────────────────────────────
+// The base include covers shapes, transforms, distributors, masks, etc.
+// Specialized modules (gears, screws, threading, etc.) need explicit includes.
+
+const BOSL2_BASE = `include <BOSL2/std.scad>\n`
+
+// Map of node type prefixes → extra include lines needed
+const EXTRA_INCLUDES: Record<string, string> = {
+  bosl2_spur_gear: 'include <BOSL2/gears.scad>\n',
+  bosl2_rack: 'include <BOSL2/gears.scad>\n',
+  bosl2_bevel_gear: 'include <BOSL2/gears.scad>\n',
+  bosl2_worm: 'include <BOSL2/gears.scad>\n',
+  bosl2_worm_gear: 'include <BOSL2/gears.scad>\n',
+  bosl2_threaded_rod: 'include <BOSL2/threading.scad>\n',
+  bosl2_threaded_nut: 'include <BOSL2/threading.scad>\n',
+  bosl2_screw: 'include <BOSL2/screws.scad>\n',
+  bosl2_screw_hole: 'include <BOSL2/screws.scad>\n',
+  bosl2_nut: 'include <BOSL2/screws.scad>\n',
+  bosl2_dovetail: 'include <BOSL2/joiners.scad>\n',
+  bosl2_snap_pin: 'include <BOSL2/joiners.scad>\n',
+  bosl2_knuckle_hinge: 'include <BOSL2/hinges.scad>\n',
+  bosl2_bottle_neck: 'include <BOSL2/bottlecaps.scad>\n',
+  bosl2_bottle_cap: 'include <BOSL2/bottlecaps.scad>\n',
+}
+
+/**
+ * Returns the BOSL2 preamble (include lines) needed for the given set of nodes.
+ * Returns null if no BOSL2 nodes are present.
+ */
+export function bosl2Preamble(nodes: Node[]): string | null {
+  const types = new Set(nodes.map((n) => n.type))
+  const hasAnyBosl2 = [...types].some((t) => t?.startsWith('bosl2_'))
+  if (!hasAnyBosl2) return null
+
+  let preamble = BOSL2_BASE
+
+  // Collect unique extra includes
+  const extras = new Set<string>()
+  for (const t of types) {
+    if (t && EXTRA_INCLUDES[t]) {
+      extras.add(EXTRA_INCLUDES[t])
+    }
+  }
+  for (const inc of extras) {
+    preamble += inc
+  }
+
+  return preamble
+}

--- a/src/nodepacks/bosl2/types/attachments.ts
+++ b/src/nodepacks/bosl2/types/attachments.ts
@@ -1,0 +1,38 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 6: Attachments & Advanced ──────────────────────────────────────────
+
+export interface Bosl2DiffData {
+  remove: string; keep: string
+}
+
+export interface Bosl2IntersectData {
+  intersect: string; keep: string
+}
+
+export interface Bosl2PositionData {
+  at: string
+}
+
+export interface Bosl2AttachData {
+  parent: string; child: string
+  overlap: Expr
+}
+
+export interface Bosl2TagData {
+  tag: string
+}
+
+export interface Bosl2RecolorData {
+  c: string
+}
+
+export interface Bosl2HalfOfData {
+  vx: Expr; vy: Expr; vz: Expr
+  cpx: Expr; cpy: Expr; cpz: Expr
+}
+
+export interface Bosl2PartitionData {
+  x: Expr; y: Expr; z: Expr
+  spread: Expr; cutpath: string
+}

--- a/src/nodepacks/bosl2/types/mechanical.ts
+++ b/src/nodepacks/bosl2/types/mechanical.ts
@@ -1,0 +1,84 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 5: Mechanical Parts ────────────────────────────────────────────────
+
+export interface Bosl2SpurGearData {
+  mod: Expr; teeth: Expr; thickness: Expr
+  pressure_angle: Expr; helical: Expr; shaft_diam: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2RackData {
+  mod: Expr; teeth: Expr; thickness: Expr
+  pressure_angle: Expr; helical: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2BevelGearData {
+  mod: Expr; teeth: Expr; mate_teeth: Expr
+  shaft_angle: Expr; face_width: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2WormData {
+  mod: Expr; d: Expr; l: Expr; starts: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2WormGearData {
+  mod: Expr; teeth: Expr; worm_diam: Expr; worm_starts: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2ThreadedRodData {
+  d: Expr; l: Expr; pitch: Expr; internal: boolean
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2ThreadedNutData {
+  nutwidth: Expr; id: Expr; h: Expr; pitch: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2ScrewData {
+  spec: string; head: string; drive: string
+  length: Expr; thread_len: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2ScrewHoleData {
+  spec: string; head: string
+  length: Expr; oversize: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2NutData {
+  spec: string; shape: string; thickness: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2DovetailData {
+  gender: string; width: Expr; height: Expr
+  slope: Expr; slide: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2SnapPinData {
+  r: Expr; l: Expr; nub_depth: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2KnuckleHingeData {
+  length: Expr; offset: Expr; segs: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2BottleNeckData {
+  wall: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2BottleCapData {
+  wall: Expr; texture: string
+  anchor: string; spin: Expr; orient: string
+}

--- a/src/nodepacks/bosl2/types/rounding.ts
+++ b/src/nodepacks/bosl2/types/rounding.ts
@@ -1,0 +1,59 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 4: Rounding, Masks, Sweeps ─────────────────────────────────────────
+
+export interface Bosl2OffsetSweepData {
+  height: Expr; top_r: Expr; bot_r: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2RoundedPrismData {
+  height: Expr; joint_top: Expr; joint_bot: Expr; joint_sides: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2SkinData {
+  slices: Expr; method: string; style: string
+}
+
+export interface Bosl2LinearSweepData {
+  height: Expr; twist: Expr; scale: Expr; slices: Expr; center: boolean
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2RotateSweepData {
+  angle: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2PathSweepData {
+  method: string; twist: Expr; closed: boolean
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2SpiralSweepData {
+  h: Expr; r: Expr; turns: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2EdgeMaskData {
+  edges: string; except: string
+}
+
+export interface Bosl2CornerMaskData {
+  corners: string; except: string
+}
+
+export interface Bosl2RoundingEdgeMaskData {
+  h: Expr; r: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2ChamferEdgeMaskData {
+  h: Expr; chamfer: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2StrokeData {
+  width: Expr; closed: boolean; endcaps: string
+}

--- a/src/nodepacks/bosl2/types/shapes2d.ts
+++ b/src/nodepacks/bosl2/types/shapes2d.ts
@@ -1,0 +1,65 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 2: 2D Shape Primitives ──────────────────────────────────────────────
+
+export interface Bosl2RectData {
+  x: Expr; y: Expr
+  rounding: Expr; chamfer: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2EllipseData {
+  rx: Expr; ry: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2RegularNgonData {
+  n: Expr; r: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2PentagonData {
+  r: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2HexagonData {
+  r: Expr; rounding: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2OctagonData {
+  r: Expr; rounding: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2StarData {
+  n: Expr; r: Expr; ir: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2TrapezoidData {
+  h: Expr; w1: Expr; w2: Expr
+  rounding: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2RightTriangleData {
+  x: Expr; y: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2Teardrop2dData {
+  r: Expr; ang: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2SquircleData {
+  x: Expr; y: Expr; squareness: Expr
+  anchor: string; spin: Expr
+}
+
+export interface Bosl2RingData {
+  n: Expr; r1: Expr; r2: Expr
+  anchor: string; spin: Expr
+}

--- a/src/nodepacks/bosl2/types/shapes3d.ts
+++ b/src/nodepacks/bosl2/types/shapes3d.ts
@@ -1,0 +1,89 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 1: 3D Shape Primitives ──────────────────────────────────────────────
+
+export interface Bosl2CuboidData {
+  x: Expr; y: Expr; z: Expr
+  rounding: Expr; chamfer: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2CylData {
+  h: Expr; r: Expr; r1: Expr; r2: Expr
+  chamfer: Expr; rounding: Expr; circum: boolean
+  fn: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2SpheroidData {
+  r: Expr; style: string; circum: boolean
+  fn: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2TorusData {
+  r_maj: Expr; r_min: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2TubeData {
+  h: Expr; or: Expr; ir: Expr; wall: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2PrismoidData {
+  size1_x: Expr; size1_y: Expr
+  size2_x: Expr; size2_y: Expr
+  h: Expr; shift_x: Expr; shift_y: Expr
+  rounding: Expr; chamfer: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2WedgeData {
+  x: Expr; y: Expr; z: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2PieSliceData {
+  h: Expr; r: Expr; ang: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2TeardropData {
+  h: Expr; r: Expr; ang: Expr; cap_h: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2OnionData {
+  r: Expr; ang: Expr; cap_h: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2RectTubeData {
+  h: Expr
+  size_x: Expr; size_y: Expr
+  isize_x: Expr; isize_y: Expr
+  wall: Expr; rounding: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2OctahedronData {
+  size: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2RegularPrismData {
+  n: Expr; h: Expr; r: Expr
+  rounding: Expr; chamfer: Expr
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2Text3dData {
+  text: string; h: Expr; size: Expr; font: string
+  anchor: string; spin: Expr; orient: string
+}
+
+export interface Bosl2FilletData {
+  h: Expr; r: Expr; ang: Expr
+  anchor: string; spin: Expr; orient: string
+}

--- a/src/nodepacks/bosl2/types/transforms.ts
+++ b/src/nodepacks/bosl2/types/transforms.ts
@@ -1,0 +1,24 @@
+import type { Expr } from '@/types/nodes'
+
+// ─── Tier 3: Transforms ──────────────────────────────────────────────────────
+
+export interface Bosl2MoveData { x: Expr; y: Expr; z: Expr }
+export interface Bosl2DirectionData { d: Expr }
+export interface Bosl2RotData { a: Expr; vx: Expr; vy: Expr; vz: Expr }
+export interface Bosl2AxisRotData { a: Expr }
+export interface Bosl2AxisScaleData { factor: Expr }
+export interface Bosl2AxisFlipData { offset: Expr }
+export interface Bosl2SkewData {
+  sxy: Expr; sxz: Expr; syx: Expr; syz: Expr; szx: Expr; szy: Expr
+}
+
+// ─── Tier 3: Distributors ────────────────────────────────────────────────────
+
+export interface Bosl2AxisCopiesData { spacing: Expr; n: Expr }
+export interface Bosl2GridCopiesData {
+  spacing_x: Expr; spacing_y: Expr; n_x: Expr; n_y: Expr; stagger: boolean
+}
+export interface Bosl2RotCopiesData { n: Expr; sa: Expr }
+export interface Bosl2ArcCopiesData { n: Expr; r: Expr; sa: Expr; ea: Expr }
+export interface Bosl2MirrorCopyData { vx: Expr; vy: Expr; vz: Expr; offset: Expr }
+export interface Bosl2PathCopiesData { path: string; n: Expr; closed: boolean }

--- a/src/nodepacks/index.ts
+++ b/src/nodepacks/index.ts
@@ -3,15 +3,28 @@ import type { NodePackDefinition } from '@/types/nodePack'
 import type { PaletteItem } from '@/types/nodes'
 import { CATEGORY_COLORS, CATEGORY_TEXT, CATEGORY_LABELS } from '@/types/nodes'
 import { makerbeamPack } from './makerbeam'
+import {
+  bosl2Shapes3dPack,
+  bosl2Shapes2dPack,
+  bosl2TransformsPack,
+  bosl2DistributorsPack,
+  bosl2RoundingPack,
+  bosl2MechanicalPack,
+  bosl2AttachmentsPack,
+} from './bosl2'
 
 // ─── Pack registry ────────────────────────────────────────────────────────────
 // Add new packs here. Each entry is a self-contained NodePackDefinition.
-// Example for future use:
-//   import { bosl2Pack } from './bosl2'
-//   NODE_PACKS.push(bosl2Pack)
 
 export const NODE_PACKS: NodePackDefinition[] = [
   makerbeamPack,
+  bosl2Shapes3dPack,
+  bosl2Shapes2dPack,
+  bosl2TransformsPack,
+  bosl2DistributorsPack,
+  bosl2RoundingPack,
+  bosl2MechanicalPack,
+  bosl2AttachmentsPack,
 ]
 
 // ─── Populate core category maps with pack entries ───────────────────────────


### PR DESCRIPTION
Create React node components for all BOSL2 3D shape primitives:
CuboidNode, CylNode, SpheroidNode, TorusNode, TubeNode,
PrismoidNode, WedgeNode, PieSliceNode, TeardropNode, OnionNode,
RectTubeNode, OctahedronNode, RegularPrismNode, Text3dNode, FilletNode

Each uses BaseNode with category='bosl2_shapes3d', ExpressionInput for
numeric params, and appropriate specialized inputs (CheckboxInput,
SelectInput, TextInput) where needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Co-authored-by: mwhite454 <7529894+mwhite454@users.noreply.github.com>