### PR TITLE
Add input handles to BOSL2 transform nodes for node connections

### DIFF
--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { Node } from '@xyflow/react'
 import type { CodegenContext } from '@/types/nodePack'
 
@@ -505,6 +505,45 @@ describe('BOSL2 Codegen Handlers', () => {
       const node = mockNode('bosl2_skew', { sxy: 0.5, sxz: 0, syx: 0, syz: 0.3, szx: 0, szy: 0 })
       const result = transformsCodegen.bosl2_skew(node, mockCtx)
       expect(result).toContain('skew(sxy = 0.5, syz = 0.3)')
+    })
+
+    // ─── resolveValueInput index assertions ─────────────────────────────────────
+
+    it('move – resolveValueInput called with correct indices (1=x, 2=y, 3=z)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_move', { x: 10, y: 20, z: 30 })
+      transformsCodegen.bosl2_move(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledWith(2, '20')
+      expect(spy).toHaveBeenCalledWith(3, '30')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('rot – resolveValueInput called with correct indices (1=a, 2=vx, 3=vy, 4=vz)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_rot', { a: 45, vx: 1, vy: 0, vz: 0 })
+      transformsCodegen.bosl2_rot(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '45')
+      expect(spy).toHaveBeenCalledWith(2, '1')
+      expect(spy).toHaveBeenCalledWith(3, '0')
+      expect(spy).toHaveBeenCalledWith(4, '0')
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
+
+    it('skew – resolveValueInput called with correct indices (1=sxy … 6=szy)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_skew', { sxy: 0.1, sxz: 0.2, syx: 0.3, syz: 0.4, szx: 0.5, szy: 0.6 })
+      transformsCodegen.bosl2_skew(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '0.1')
+      expect(spy).toHaveBeenCalledWith(2, '0.2')
+      expect(spy).toHaveBeenCalledWith(3, '0.3')
+      expect(spy).toHaveBeenCalledWith(4, '0.4')
+      expect(spy).toHaveBeenCalledWith(5, '0.5')
+      expect(spy).toHaveBeenCalledWith(6, '0.6')
+      expect(spy).toHaveBeenCalledTimes(6)
     })
   })
 

--- a/src/nodepacks/bosl2/codegen/transformsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/transformsCodegen.ts
@@ -6,38 +6,43 @@ import type { CodegenContext } from '@/types/nodePack'
 export const transformsCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
   bosl2_move: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`move([${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}])`)
+    const x = ctx.resolveValueInput(1, ctx.expr(d.x))
+    const y = ctx.resolveValueInput(2, ctx.expr(d.y))
+    const z = ctx.resolveValueInput(3, ctx.expr(d.z))
+    return ctx.emitTransform(`move([${x}, ${y}, ${z}])`)
   },
 
   bosl2_left: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`left(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`left(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
   bosl2_right: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`right(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`right(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
   bosl2_fwd: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`fwd(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`fwd(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
   bosl2_back: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`back(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`back(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
   bosl2_up: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`up(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`up(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
   bosl2_down: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`down(${ctx.expr(d.d)})`)
+    return ctx.emitTransform(`down(${ctx.resolveValueInput(1, ctx.expr(d.d))})`)
   },
 
   bosl2_rot: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const a = ctx.expr(d.a)
-    const vx = ctx.expr(d.vx); const vy = ctx.expr(d.vy); const vz = ctx.expr(d.vz)
+    const a  = ctx.resolveValueInput(1, ctx.expr(d.a))
+    const vx = ctx.resolveValueInput(2, ctx.expr(d.vx))
+    const vy = ctx.resolveValueInput(3, ctx.expr(d.vy))
+    const vz = ctx.resolveValueInput(4, ctx.expr(d.vz))
     if (vx !== '0' || vy !== '0' || vz !== '0') {
       return ctx.emitTransform(`rot(a = ${a}, v = [${vx}, ${vy}, ${vz}])`)
     }
@@ -46,55 +51,55 @@ export const transformsCodegen: Record<string, (node: Node, ctx: CodegenContext)
 
   bosl2_xrot: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`xrot(${ctx.expr(d.a)})`)
+    return ctx.emitTransform(`xrot(${ctx.resolveValueInput(1, ctx.expr(d.a))})`)
   },
   bosl2_yrot: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`yrot(${ctx.expr(d.a)})`)
+    return ctx.emitTransform(`yrot(${ctx.resolveValueInput(1, ctx.expr(d.a))})`)
   },
   bosl2_zrot: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`zrot(${ctx.expr(d.a)})`)
+    return ctx.emitTransform(`zrot(${ctx.resolveValueInput(1, ctx.expr(d.a))})`)
   },
 
   bosl2_xscale: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`xscale(${ctx.expr(d.factor)})`)
+    return ctx.emitTransform(`xscale(${ctx.resolveValueInput(1, ctx.expr(d.factor))})`)
   },
   bosl2_yscale: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`yscale(${ctx.expr(d.factor)})`)
+    return ctx.emitTransform(`yscale(${ctx.resolveValueInput(1, ctx.expr(d.factor))})`)
   },
   bosl2_zscale: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    return ctx.emitTransform(`zscale(${ctx.expr(d.factor)})`)
+    return ctx.emitTransform(`zscale(${ctx.resolveValueInput(1, ctx.expr(d.factor))})`)
   },
 
   bosl2_xflip: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const off = ctx.expr(d.offset)
+    const off = ctx.resolveValueInput(1, ctx.expr(d.offset))
     return ctx.emitTransform(off !== '0' ? `xflip(x = ${off})` : `xflip()`)
   },
   bosl2_yflip: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const off = ctx.expr(d.offset)
+    const off = ctx.resolveValueInput(1, ctx.expr(d.offset))
     return ctx.emitTransform(off !== '0' ? `yflip(y = ${off})` : `yflip()`)
   },
   bosl2_zflip: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const off = ctx.expr(d.offset)
+    const off = ctx.resolveValueInput(1, ctx.expr(d.offset))
     return ctx.emitTransform(off !== '0' ? `zflip(z = ${off})` : `zflip()`)
   },
 
   bosl2_skew: (node, ctx) => {
     const d = node.data as Record<string, unknown>
     const parts: string[] = []
-    const add = (name: string, val: unknown) => {
-      const v = ctx.expr(val); if (v !== '0') parts.push(`${name} = ${v}`)
+    const add = (name: string, val: unknown, idx: number) => {
+      const v = ctx.resolveValueInput(idx, ctx.expr(val)); if (v !== '0') parts.push(`${name} = ${v}`)
     }
-    add('sxy', d.sxy); add('sxz', d.sxz)
-    add('syx', d.syx); add('syz', d.syz)
-    add('szx', d.szx); add('szy', d.szy)
+    add('sxy', d.sxy, 1); add('sxz', d.sxz, 2)
+    add('syx', d.syx, 3); add('syz', d.syz, 4)
+    add('szx', d.szx, 5); add('szy', d.szy, 6)
     return ctx.emitTransform(`skew(${parts.join(', ')})`)
   },
 }

--- a/src/nodepacks/bosl2/codegen/transformsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/transformsCodegen.ts
@@ -39,7 +39,7 @@ export const transformsCodegen: Record<string, (node: Node, ctx: CodegenContext)
 
   bosl2_rot: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const a  = ctx.resolveValueInput(1, ctx.expr(d.a))
+    const a = ctx.resolveValueInput(1, ctx.expr(d.a))
     const vx = ctx.resolveValueInput(2, ctx.expr(d.vx))
     const vy = ctx.resolveValueInput(3, ctx.expr(d.vy))
     const vz = ctx.resolveValueInput(4, ctx.expr(d.vz))

--- a/src/nodepacks/bosl2/nodes/transforms/BackNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/BackNode.tsx
@@ -7,7 +7,8 @@ export function BackNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="back" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="back" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/DownNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/DownNode.tsx
@@ -7,7 +7,8 @@ export function DownNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="down" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="down" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/FwdNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/FwdNode.tsx
@@ -7,7 +7,8 @@ export function FwdNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="fwd" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="fwd" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/LeftNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/LeftNode.tsx
@@ -7,7 +7,8 @@ export function LeftNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="left" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="left" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/MoveNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/MoveNode.tsx
@@ -7,7 +7,13 @@ export function MoveNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2MoveData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="move" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="move" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'x' },
+        { id: 'in-2', label: 'y' },
+        { id: 'in-3', label: 'z' },
+      ]}>
       <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
       <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
       <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />

--- a/src/nodepacks/bosl2/nodes/transforms/RightNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/RightNode.tsx
@@ -7,7 +7,8 @@ export function RightNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="right" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="right" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/RotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/RotNode.tsx
@@ -7,7 +7,14 @@ export function RotNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RotData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="rot" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="rot" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'a' },
+        { id: 'in-2', label: 'vx' },
+        { id: 'in-3', label: 'vy' },
+        { id: 'in-4', label: 'vz' },
+      ]}>
       <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
       <ExpressionInput label="vx" value={d.vx} step={1} onChange={(v) => update(id, { vx: v })} />
       <ExpressionInput label="vy" value={d.vy} step={1} onChange={(v) => update(id, { vy: v })} />

--- a/src/nodepacks/bosl2/nodes/transforms/SkewNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/SkewNode.tsx
@@ -7,7 +7,16 @@ export function SkewNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2SkewData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="skew" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="skew" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'sxy' },
+        { id: 'in-2', label: 'sxz' },
+        { id: 'in-3', label: 'syx' },
+        { id: 'in-4', label: 'syz' },
+        { id: 'in-5', label: 'szx' },
+        { id: 'in-6', label: 'szy' },
+      ]}>
       <ExpressionInput label="sxy" value={d.sxy} step={0.1} onChange={(v) => update(id, { sxy: v })} />
       <ExpressionInput label="sxz" value={d.sxz} step={0.1} onChange={(v) => update(id, { sxz: v })} />
       <ExpressionInput label="syx" value={d.syx} step={0.1} onChange={(v) => update(id, { syx: v })} />

--- a/src/nodepacks/bosl2/nodes/transforms/UpNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/UpNode.tsx
@@ -7,7 +7,8 @@ export function UpNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2DirectionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="up" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="up" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'd' }]}>
       <ExpressionInput label="d" value={d.d} step={1} onChange={(v) => update(id, { d: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/XflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XflipNode.tsx
@@ -7,7 +7,8 @@ export function XflipNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisFlipData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="xflip" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="xflip" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'offset' }]}>
       <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/XrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XrotNode.tsx
@@ -7,7 +7,8 @@ export function XrotNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisRotData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="xrot" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="xrot" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'a' }]}>
       <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/XscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/XscaleNode.tsx
@@ -7,7 +7,8 @@ export function XscaleNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisScaleData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="xscale" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="xscale" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'factor' }]}>
       <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/YflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YflipNode.tsx
@@ -7,7 +7,8 @@ export function YflipNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisFlipData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="yflip" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="yflip" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'offset' }]}>
       <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/YrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YrotNode.tsx
@@ -7,7 +7,8 @@ export function YrotNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisRotData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="yrot" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="yrot" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'a' }]}>
       <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/YscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/YscaleNode.tsx
@@ -7,7 +7,8 @@ export function YscaleNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisScaleData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="yscale" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="yscale" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'factor' }]}>
       <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/ZflipNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZflipNode.tsx
@@ -7,7 +7,8 @@ export function ZflipNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisFlipData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="zflip" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="zflip" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'offset' }]}>
       <ExpressionInput label="offset" value={d.offset} step={1} onChange={(v) => update(id, { offset: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/ZrotNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZrotNode.tsx
@@ -7,7 +7,8 @@ export function ZrotNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisRotData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="zrot" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="zrot" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'a' }]}>
       <ExpressionInput label="a" value={d.a} step={1} onChange={(v) => update(id, { a: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/transforms/ZscaleNode.tsx
+++ b/src/nodepacks/bosl2/nodes/transforms/ZscaleNode.tsx
@@ -7,7 +7,8 @@ export function ZscaleNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AxisScaleData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_transforms" label="zscale" selected={selected}>
+    <BaseNode id={id} category="bosl2_transforms" label="zscale" selected={selected}
+      inputHandles={[{ id: 'in-0', label: 'child' }, { id: 'in-1', label: 'factor' }]}>
       <ExpressionInput label="factor" value={d.factor} step={0.1} onChange={(v) => update(id, { factor: v })} />
     </BaseNode>
   )


### PR DESCRIPTION
## Summary
This PR adds input handle support to all BOSL2 transform nodes, enabling them to receive values from other nodes via connections. The codegen has been updated to use `resolveValueInput()` to properly resolve connected node values.

## Key Changes
- **Codegen Updates**: Modified `transformsCodegen.ts` to wrap all parameter expressions with `ctx.resolveValueInput()` calls, allowing parameters to accept values from connected input nodes
  - Each parameter now has a unique input index (starting from 1, with 0 reserved for the child input)
  - Updated all transform functions: move, left, right, fwd, back, up, down, rot, xrot, yrot, zrot, xscale, yscale, zscale, xflip, yflip, zflip, and skew

- **Node UI Updates**: Added `inputHandles` prop to all transform node components with properly labeled input handles
  - Single-parameter nodes (direction, rotation, scale, flip): 2 handles (child + parameter)
  - Multi-parameter nodes (move, rot, skew): 3-7 handles depending on parameters
  - Each handle is labeled with its corresponding parameter name for clarity

## Implementation Details
- Input handle IDs follow the pattern `in-0` (child), `in-1` (first param), `in-2` (second param), etc.
- The `resolveValueInput()` method is called with the handle index and the default expression value
- This allows transform parameters to be driven by upstream nodes while maintaining backward compatibility with static expression values

https://claude.ai/code/session_01Vzw3g8DXNfVs31PZ39EFMM