### PR TITLE
feat: add input edges to BOSL2 3D primitive nodes

### DIFF
--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -250,6 +250,179 @@ describe('BOSL2 Codegen Handlers', () => {
     })
   })
 
+  // ─── resolveValueInput index assertions for shapes3d ────────────────────────
+
+  describe('shapes3d – resolveValueInput index assertions', () => {
+    it('cuboid – indices 0=x, 1=y, 2=z, 3=rounding, 4=chamfer', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_cuboid', { x: 10, y: 20, z: 30, rounding: 2, chamfer: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_cuboid(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '20')
+      expect(spy).toHaveBeenCalledWith(2, '30')
+      expect(spy).toHaveBeenCalledWith(3, '2')
+      expect(spy).toHaveBeenCalledWith(4, '1')
+      expect(spy).toHaveBeenCalledTimes(5)
+    })
+
+    it('cyl – indices 0=h, 1=r, 2=r1, 3=r2, 4=chamfer, 5=rounding, 6=fn', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_cyl', { h: 10, r: 5, r1: 5, r2: 5, chamfer: 1, rounding: 2, circum: false, fn: 64, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_cyl(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '5')
+      expect(spy).toHaveBeenCalledWith(2, '5')
+      expect(spy).toHaveBeenCalledWith(3, '5')
+      expect(spy).toHaveBeenCalledWith(4, '1')
+      expect(spy).toHaveBeenCalledWith(5, '2')
+      expect(spy).toHaveBeenCalledWith(6, '64')
+      expect(spy).toHaveBeenCalledTimes(7)
+    })
+
+    it('spheroid – indices 0=r, 1=fn', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_spheroid', { r: 10, style: 'aligned', circum: false, fn: 64, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_spheroid(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '64')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('torus – indices 0=r_maj, 1=r_min', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_torus', { r_maj: 20, r_min: 5, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_torus(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledWith(1, '5')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('tube – indices 0=h, 1=or, 2=ir, 3=wall', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_tube', { h: 20, or: 10, ir: 8, wall: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_tube(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledWith(2, '8')
+      expect(spy).toHaveBeenCalledWith(3, '2')
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
+
+    it('prismoid – indices 0..8', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_prismoid', { size1_x: 20, size1_y: 20, size2_x: 10, size2_y: 10, h: 15, shift_x: 5, shift_y: 3, rounding: 2, chamfer: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_prismoid(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')  // size1_x
+      expect(spy).toHaveBeenCalledWith(1, '20')  // size1_y
+      expect(spy).toHaveBeenCalledWith(2, '10')  // size2_x
+      expect(spy).toHaveBeenCalledWith(3, '10')  // size2_y
+      expect(spy).toHaveBeenCalledWith(4, '15')  // h
+      expect(spy).toHaveBeenCalledWith(5, '5')   // shift_x
+      expect(spy).toHaveBeenCalledWith(6, '3')   // shift_y
+      expect(spy).toHaveBeenCalledWith(7, '2')   // rounding
+      expect(spy).toHaveBeenCalledWith(8, '1')   // chamfer
+      expect(spy).toHaveBeenCalledTimes(9)
+    })
+
+    it('wedge – indices 0=x, 1=y, 2=z', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_wedge', { x: 10, y: 20, z: 30, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_wedge(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '20')
+      expect(spy).toHaveBeenCalledWith(2, '30')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('pie_slice – indices 0=h, 1=r, 2=ang', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_pie_slice', { h: 10, r: 10, ang: 90, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_pie_slice(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledWith(2, '90')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('teardrop – indices 0=h, 1=r, 2=ang, 3=cap_h', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_teardrop', { h: 10, r: 5, ang: 60, cap_h: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_teardrop(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '5')
+      expect(spy).toHaveBeenCalledWith(2, '60')
+      expect(spy).toHaveBeenCalledWith(3, '3')
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
+
+    it('onion – indices 0=r, 1=ang, 2=cap_h', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_onion', { r: 10, ang: 60, cap_h: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_onion(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '60')
+      expect(spy).toHaveBeenCalledWith(2, '3')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('rect_tube – indices 0=h, 1=size_x, 2=size_y, 3=isize_x, 4=isize_y, 5=wall, 6=rounding', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_rect_tube', { h: 20, size_x: 20, size_y: 20, isize_x: 16, isize_y: 16, wall: 2, rounding: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_rect_tube(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')  // h
+      expect(spy).toHaveBeenCalledWith(1, '20')  // size_x
+      expect(spy).toHaveBeenCalledWith(2, '20')  // size_y
+      expect(spy).toHaveBeenCalledWith(3, '16')  // isize_x
+      expect(spy).toHaveBeenCalledWith(4, '16')  // isize_y
+      expect(spy).toHaveBeenCalledWith(5, '2')   // wall
+      expect(spy).toHaveBeenCalledWith(6, '1')   // rounding
+      expect(spy).toHaveBeenCalledTimes(7)
+    })
+
+    it('octahedron – index 0=size', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_octahedron', { size: 20, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_octahedron(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('regular_prism – indices 0=n, 1=h, 2=r, 3=rounding, 4=chamfer', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_regular_prism', { n: 6, h: 10, r: 5, rounding: 2, chamfer: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_regular_prism(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '6')
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledWith(2, '5')
+      expect(spy).toHaveBeenCalledWith(3, '2')
+      expect(spy).toHaveBeenCalledWith(4, '1')
+      expect(spy).toHaveBeenCalledTimes(5)
+    })
+
+    it('text3d – indices 0=h, 1=size', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_text3d', { text: 'Hello', h: 2, size: 10, font: 'Liberation Sans', anchor: 'CENTER', spin: 0, orient: 'UP' })
+      shapes3dCodegen.bosl2_text3d(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '2')
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
+
   // ═══════════════════════════════════════════════════════════════════════════════
   // Tier 2: 2D Shapes
   // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
@@ -26,7 +26,7 @@ export const shapes3dCodegen: Record<string, (node: Node, ctx: CodegenContext) =
     if (r1 !== r2) {
       params += `, r1 = ${r1}, r2 = ${r2}`
     } else {
-      params += `, r = ${r}`
+      params += `, r = ${r1}`
     }
     const ch = ctx.resolveValueInput(4, ctx.expr(d.chamfer)); if (ch !== '0') params += `, chamfer = ${ch}`
     const ro = ctx.resolveValueInput(5, ctx.expr(d.rounding)); if (ro !== '0') params += `, rounding = ${ro}`

--- a/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/shapes3dCodegen.ts
@@ -7,54 +7,57 @@ import { optAnchor } from './utils'
 export const shapes3dCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
   bosl2_cuboid: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const size = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    const xE = ctx.resolveValueInput(0, ctx.expr(d.x))
+    const yE = ctx.resolveValueInput(1, ctx.expr(d.y))
+    const zE = ctx.resolveValueInput(2, ctx.expr(d.z))
+    const size = `[${xE}, ${yE}, ${zE}]`
     let params = size
-    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
-    const c = ctx.expr(d.chamfer); if (c !== '0') params += `, chamfer = ${c}`
+    const r = ctx.resolveValueInput(3, ctx.expr(d.rounding)); if (r !== '0') params += `, rounding = ${r}`
+    const c = ctx.resolveValueInput(4, ctx.expr(d.chamfer)); if (c !== '0') params += `, chamfer = ${c}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}cuboid(${params});\n`
   },
 
   bosl2_cyl: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}`
-    const r1 = ctx.expr(d.r1); const r2 = ctx.expr(d.r2)
-    const r = ctx.expr(d.r)
+    let params = `h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}`
+    const r1 = ctx.resolveValueInput(2, ctx.expr(d.r1)); const r2 = ctx.resolveValueInput(3, ctx.expr(d.r2))
+    const r = ctx.resolveValueInput(1, ctx.expr(d.r))
     if (r1 !== r2) {
       params += `, r1 = ${r1}, r2 = ${r2}`
     } else {
       params += `, r = ${r}`
     }
-    const ch = ctx.expr(d.chamfer); if (ch !== '0') params += `, chamfer = ${ch}`
-    const ro = ctx.expr(d.rounding); if (ro !== '0') params += `, rounding = ${ro}`
+    const ch = ctx.resolveValueInput(4, ctx.expr(d.chamfer)); if (ch !== '0') params += `, chamfer = ${ch}`
+    const ro = ctx.resolveValueInput(5, ctx.expr(d.rounding)); if (ro !== '0') params += `, rounding = ${ro}`
     if (d.circum) params += `, circum = true`
-    const fn = ctx.expr(d.fn); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
+    const fn = ctx.resolveValueInput(6, ctx.expr(d.fn)); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}cyl(${params});\n`
   },
 
   bosl2_spheroid: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `r = ${ctx.expr(d.r)}`
+    let params = `r = ${ctx.resolveValueInput(0, ctx.expr(d.r))}`
     const style = String(d.style ?? 'aligned')
     if (style !== 'aligned') params += `, style = "${style}"`
     if (d.circum) params += `, circum = true`
-    const fn = ctx.expr(d.fn); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
+    const fn = ctx.resolveValueInput(1, ctx.expr(d.fn)); if (fn !== '0' && fn !== '32') params += `, $fn = ${fn}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}spheroid(${params});\n`
   },
 
   bosl2_torus: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `r_maj = ${ctx.expr(d.r_maj)}, r_min = ${ctx.expr(d.r_min)}`
+    let params = `r_maj = ${ctx.resolveValueInput(0, ctx.expr(d.r_maj))}, r_min = ${ctx.resolveValueInput(1, ctx.expr(d.r_min))}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}torus(${params});\n`
   },
 
   bosl2_tube: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, or = ${ctx.expr(d.or)}`
-    const ir = ctx.expr(d.ir); const wall = ctx.expr(d.wall)
+    let params = `h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}, or = ${ctx.resolveValueInput(1, ctx.expr(d.or))}`
+    const ir = ctx.resolveValueInput(2, ctx.expr(d.ir)); const wall = ctx.resolveValueInput(3, ctx.expr(d.wall))
     if (ir !== '0') params += `, ir = ${ir}`
     if (wall !== '0') params += `, wall = ${wall}`
     params += optAnchor(ctx, d)
@@ -63,72 +66,72 @@ export const shapes3dCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_prismoid: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const s1 = `[${ctx.expr(d.size1_x)}, ${ctx.expr(d.size1_y)}]`
-    const s2 = `[${ctx.expr(d.size2_x)}, ${ctx.expr(d.size2_y)}]`
-    let params = `${s1}, ${s2}, h = ${ctx.expr(d.h)}`
-    const sx = ctx.expr(d.shift_x); const sy = ctx.expr(d.shift_y)
+    const s1 = `[${ctx.resolveValueInput(0, ctx.expr(d.size1_x))}, ${ctx.resolveValueInput(1, ctx.expr(d.size1_y))}]`
+    const s2 = `[${ctx.resolveValueInput(2, ctx.expr(d.size2_x))}, ${ctx.resolveValueInput(3, ctx.expr(d.size2_y))}]`
+    let params = `${s1}, ${s2}, h = ${ctx.resolveValueInput(4, ctx.expr(d.h))}`
+    const sx = ctx.resolveValueInput(5, ctx.expr(d.shift_x)); const sy = ctx.resolveValueInput(6, ctx.expr(d.shift_y))
     if (sx !== '0' || sy !== '0') params += `, shift = [${sx}, ${sy}]`
-    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
-    const c = ctx.expr(d.chamfer); if (c !== '0') params += `, chamfer = ${c}`
+    const r = ctx.resolveValueInput(7, ctx.expr(d.rounding)); if (r !== '0') params += `, rounding = ${r}`
+    const c = ctx.resolveValueInput(8, ctx.expr(d.chamfer)); if (c !== '0') params += `, chamfer = ${c}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}prismoid(${params});\n`
   },
 
   bosl2_wedge: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    let params = `[${ctx.resolveValueInput(0, ctx.expr(d.x))}, ${ctx.resolveValueInput(1, ctx.expr(d.y))}, ${ctx.resolveValueInput(2, ctx.expr(d.z))}]`
     params += optAnchor(ctx, d)
     return `${ctx.pad}wedge(${params});\n`
   },
 
   bosl2_pie_slice: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}, ang = ${ctx.expr(d.ang)}`
+    let params = `h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}, r = ${ctx.resolveValueInput(1, ctx.expr(d.r))}, ang = ${ctx.resolveValueInput(2, ctx.expr(d.ang))}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}pie_slice(${params});\n`
   },
 
   bosl2_teardrop: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
-    const ang = ctx.expr(d.ang); if (ang !== '45') params += `, ang = ${ang}`
-    const cap = ctx.expr(d.cap_h); if (cap !== '0') params += `, cap_h = ${cap}`
+    let params = `h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}, r = ${ctx.resolveValueInput(1, ctx.expr(d.r))}`
+    const ang = ctx.resolveValueInput(2, ctx.expr(d.ang)); if (ang !== '45') params += `, ang = ${ang}`
+    const cap = ctx.resolveValueInput(3, ctx.expr(d.cap_h)); if (cap !== '0') params += `, cap_h = ${cap}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}teardrop(${params});\n`
   },
 
   bosl2_onion: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `r = ${ctx.expr(d.r)}`
-    const ang = ctx.expr(d.ang); if (ang !== '45') params += `, ang = ${ang}`
-    const cap = ctx.expr(d.cap_h); if (cap !== '0') params += `, cap_h = ${cap}`
+    let params = `r = ${ctx.resolveValueInput(0, ctx.expr(d.r))}`
+    const ang = ctx.resolveValueInput(1, ctx.expr(d.ang)); if (ang !== '45') params += `, ang = ${ang}`
+    const cap = ctx.resolveValueInput(2, ctx.expr(d.cap_h)); if (cap !== '0') params += `, cap_h = ${cap}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}onion(${params});\n`
   },
 
   bosl2_rect_tube: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const size = `[${ctx.expr(d.size_x)}, ${ctx.expr(d.size_y)}]`
-    const isize = `[${ctx.expr(d.isize_x)}, ${ctx.expr(d.isize_y)}]`
-    let params = `h = ${ctx.expr(d.h)}, size = ${size}, isize = ${isize}`
-    const wall = ctx.expr(d.wall); if (wall !== '0') params += `, wall = ${wall}`
-    const r = ctx.expr(d.rounding); if (r !== '0') params += `, rounding = ${r}`
+    const size = `[${ctx.resolveValueInput(1, ctx.expr(d.size_x))}, ${ctx.resolveValueInput(2, ctx.expr(d.size_y))}]`
+    const isize = `[${ctx.resolveValueInput(3, ctx.expr(d.isize_x))}, ${ctx.resolveValueInput(4, ctx.expr(d.isize_y))}]`
+    let params = `h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}, size = ${size}, isize = ${isize}`
+    const wall = ctx.resolveValueInput(5, ctx.expr(d.wall)); if (wall !== '0') params += `, wall = ${wall}`
+    const r = ctx.resolveValueInput(6, ctx.expr(d.rounding)); if (r !== '0') params += `, rounding = ${r}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}rect_tube(${params});\n`
   },
 
   bosl2_octahedron: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `size = ${ctx.expr(d.size)}`
+    let params = `size = ${ctx.resolveValueInput(0, ctx.expr(d.size))}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}octahedron(${params});\n`
   },
 
   bosl2_regular_prism: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `n = ${ctx.expr(d.n)}, h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
-    const ro = ctx.expr(d.rounding); if (ro !== '0') params += `, rounding = ${ro}`
-    const ch = ctx.expr(d.chamfer); if (ch !== '0') params += `, chamfer = ${ch}`
+    let params = `n = ${ctx.resolveValueInput(0, ctx.expr(d.n))}, h = ${ctx.resolveValueInput(1, ctx.expr(d.h))}, r = ${ctx.resolveValueInput(2, ctx.expr(d.r))}`
+    const ro = ctx.resolveValueInput(3, ctx.expr(d.rounding)); if (ro !== '0') params += `, rounding = ${ro}`
+    const ch = ctx.resolveValueInput(4, ctx.expr(d.chamfer)); if (ch !== '0') params += `, chamfer = ${ch}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}regular_prism(${params});\n`
   },
@@ -136,7 +139,7 @@ export const shapes3dCodegen: Record<string, (node: Node, ctx: CodegenContext) =
   bosl2_text3d: (node, ctx) => {
     const d = node.data as Record<string, unknown>
     const text = ctx.escapeString(d.text)
-    let params = `"${text}", h = ${ctx.expr(d.h)}, size = ${ctx.expr(d.size)}`
+    let params = `"${text}", h = ${ctx.resolveValueInput(0, ctx.expr(d.h))}, size = ${ctx.resolveValueInput(1, ctx.expr(d.size))}`
     const font = String(d.font ?? '')
     if (font) params += `, font = "${ctx.escapeString(font)}"`
     params += optAnchor(ctx, d)

--- a/src/nodepacks/bosl2/nodes/shapes3d/CuboidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/CuboidNode.tsx
@@ -7,12 +7,20 @@ export function CuboidNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2CuboidData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="cuboid" selected={selected}>
-      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
-      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
-      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
-      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
-      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="cuboid" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'x' },
+        { id: 'in-1', label: 'y' },
+        { id: 'in-2', label: 'z' },
+        { id: 'in-3', label: 'rounding' },
+        { id: 'in-4', label: 'chamfer' },
+      ]}
+    >
+      <ExpressionInput label="x" value={d.x} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { z: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} nodeId={id} handleId="in-4" onChange={(v) => update(id, { chamfer: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/CylNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/CylNode.tsx
@@ -7,14 +7,25 @@ export function CylNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2CylData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="cyl" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="r1" value={d.r1} step={1} onChange={(v) => update(id, { r1: v })} />
-      <ExpressionInput label="r2" value={d.r2} step={1} onChange={(v) => update(id, { r2: v })} />
-      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
-      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="cyl" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+        { id: 'in-2', label: 'r1' },
+        { id: 'in-3', label: 'r2' },
+        { id: 'in-4', label: 'chamfer' },
+        { id: 'in-5', label: 'rounding' },
+        { id: 'in-6', label: '$fn' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="r1" value={d.r1} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { r1: v })} />
+      <ExpressionInput label="r2" value={d.r2} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { r2: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} nodeId={id} handleId="in-4" onChange={(v) => update(id, { chamfer: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} nodeId={id} handleId="in-5" onChange={(v) => update(id, { rounding: v })} />
       <CheckboxInput label="circum" value={d.circum} onChange={(v) => update(id, { circum: v })} />
+      <ExpressionInput label="$fn" value={d.fn} step={1} nodeId={id} handleId="in-6" onChange={(v) => update(id, { fn: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/OctahedronNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/OctahedronNode.tsx
@@ -7,8 +7,12 @@ export function OctahedronNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2OctahedronData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="octahedron" selected={selected}>
-      <ExpressionInput label="size" value={d.size} step={1} onChange={(v) => update(id, { size: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="octahedron" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'size' },
+      ]}
+    >
+      <ExpressionInput label="size" value={d.size} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { size: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/OnionNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/OnionNode.tsx
@@ -7,10 +7,16 @@ export function OnionNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2OnionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="onion" selected={selected}>
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
-      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} onChange={(v) => update(id, { cap_h: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="onion" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'r' },
+        { id: 'in-1', label: 'ang' },
+        { id: 'in-2', label: 'cap_h' },
+      ]}
+    >
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { ang: v })} />
+      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { cap_h: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/PieSliceNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/PieSliceNode.tsx
@@ -7,10 +7,16 @@ export function PieSliceNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2PieSliceData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="pie_slice" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="pie_slice" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+        { id: 'in-2', label: 'ang' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { ang: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/PrismoidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/PrismoidNode.tsx
@@ -7,16 +7,28 @@ export function PrismoidNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2PrismoidData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="prismoid" selected={selected}>
-      <ExpressionInput label="size1_x" value={d.size1_x} step={1} onChange={(v) => update(id, { size1_x: v })} />
-      <ExpressionInput label="size1_y" value={d.size1_y} step={1} onChange={(v) => update(id, { size1_y: v })} />
-      <ExpressionInput label="size2_x" value={d.size2_x} step={1} onChange={(v) => update(id, { size2_x: v })} />
-      <ExpressionInput label="size2_y" value={d.size2_y} step={1} onChange={(v) => update(id, { size2_y: v })} />
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="shift_x" value={d.shift_x} step={1} onChange={(v) => update(id, { shift_x: v })} />
-      <ExpressionInput label="shift_y" value={d.shift_y} step={1} onChange={(v) => update(id, { shift_y: v })} />
-      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
-      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="prismoid" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'size1_x' },
+        { id: 'in-1', label: 'size1_y' },
+        { id: 'in-2', label: 'size2_x' },
+        { id: 'in-3', label: 'size2_y' },
+        { id: 'in-4', label: 'h' },
+        { id: 'in-5', label: 'shift_x' },
+        { id: 'in-6', label: 'shift_y' },
+        { id: 'in-7', label: 'rounding' },
+        { id: 'in-8', label: 'chamfer' },
+      ]}
+    >
+      <ExpressionInput label="size1_x" value={d.size1_x} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { size1_x: v })} />
+      <ExpressionInput label="size1_y" value={d.size1_y} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { size1_y: v })} />
+      <ExpressionInput label="size2_x" value={d.size2_x} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { size2_x: v })} />
+      <ExpressionInput label="size2_y" value={d.size2_y} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { size2_y: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-4" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="shift_x" value={d.shift_x} step={1} nodeId={id} handleId="in-5" onChange={(v) => update(id, { shift_x: v })} />
+      <ExpressionInput label="shift_y" value={d.shift_y} step={1} nodeId={id} handleId="in-6" onChange={(v) => update(id, { shift_y: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} nodeId={id} handleId="in-7" onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} nodeId={id} handleId="in-8" onChange={(v) => update(id, { chamfer: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/RectTubeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/RectTubeNode.tsx
@@ -7,14 +7,24 @@ export function RectTubeNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RectTubeData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="rect_tube" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="size_x" value={d.size_x} step={1} onChange={(v) => update(id, { size_x: v })} />
-      <ExpressionInput label="size_y" value={d.size_y} step={1} onChange={(v) => update(id, { size_y: v })} />
-      <ExpressionInput label="isize_x" value={d.isize_x} step={1} onChange={(v) => update(id, { isize_x: v })} />
-      <ExpressionInput label="isize_y" value={d.isize_y} step={1} onChange={(v) => update(id, { isize_y: v })} />
-      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
-      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="rect_tube" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'size_x' },
+        { id: 'in-2', label: 'size_y' },
+        { id: 'in-3', label: 'isize_x' },
+        { id: 'in-4', label: 'isize_y' },
+        { id: 'in-5', label: 'wall' },
+        { id: 'in-6', label: 'rounding' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="size_x" value={d.size_x} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { size_x: v })} />
+      <ExpressionInput label="size_y" value={d.size_y} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { size_y: v })} />
+      <ExpressionInput label="isize_x" value={d.isize_x} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { isize_x: v })} />
+      <ExpressionInput label="isize_y" value={d.isize_y} step={1} nodeId={id} handleId="in-4" onChange={(v) => update(id, { isize_y: v })} />
+      <ExpressionInput label="wall" value={d.wall} step={0.5} nodeId={id} handleId="in-5" onChange={(v) => update(id, { wall: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} nodeId={id} handleId="in-6" onChange={(v) => update(id, { rounding: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/RegularPrismNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/RegularPrismNode.tsx
@@ -7,12 +7,20 @@ export function RegularPrismNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RegularPrismData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="regular_prism" selected={selected}>
-      <ExpressionInput label="n" value={d.n} step={1} onChange={(v) => update(id, { n: v })} />
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="rounding" value={d.rounding} step={0.5} onChange={(v) => update(id, { rounding: v })} />
-      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="regular_prism" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'n' },
+        { id: 'in-1', label: 'h' },
+        { id: 'in-2', label: 'r' },
+        { id: 'in-3', label: 'rounding' },
+        { id: 'in-4', label: 'chamfer' },
+      ]}
+    >
+      <ExpressionInput label="n" value={d.n} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { n: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="rounding" value={d.rounding} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { rounding: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} nodeId={id} handleId="in-4" onChange={(v) => update(id, { chamfer: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/SpheroidNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/SpheroidNode.tsx
@@ -9,10 +9,16 @@ export function SpheroidNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2SpheroidData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="spheroid" selected={selected}>
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="spheroid" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'r' },
+        { id: 'in-1', label: '$fn' },
+      ]}
+    >
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { r: v })} />
       <SelectInput label="style" value={d.style} options={STYLE_OPTIONS} onChange={(v) => update(id, { style: v })} />
       <CheckboxInput label="circum" value={d.circum} onChange={(v) => update(id, { circum: v })} />
+      <ExpressionInput label="$fn" value={d.fn} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { fn: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/TeardropNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TeardropNode.tsx
@@ -7,11 +7,18 @@ export function TeardropNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2TeardropData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="teardrop" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
-      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} onChange={(v) => update(id, { cap_h: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="teardrop" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+        { id: 'in-2', label: 'ang' },
+        { id: 'in-3', label: 'cap_h' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { ang: v })} />
+      <ExpressionInput label="cap_h" value={d.cap_h} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { cap_h: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/Text3dNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/Text3dNode.tsx
@@ -7,10 +7,15 @@ export function Text3dNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2Text3dData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="text3d" selected={selected}>
+    <BaseNode id={id} category="bosl2_shapes3d" label="text3d" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'size' },
+      ]}
+    >
       <TextInput label="text" value={d.text} onChange={(v) => update(id, { text: v })} />
-      <ExpressionInput label="h" value={d.h} step={0.5} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="size" value={d.size} step={1} onChange={(v) => update(id, { size: v })} />
+      <ExpressionInput label="h" value={d.h} step={0.5} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="size" value={d.size} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { size: v })} />
       <TextInput label="font" value={d.font} onChange={(v) => update(id, { font: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/shapes3d/TorusNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TorusNode.tsx
@@ -7,9 +7,14 @@ export function TorusNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2TorusData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="torus" selected={selected}>
-      <ExpressionInput label="r_maj" value={d.r_maj} step={1} onChange={(v) => update(id, { r_maj: v })} />
-      <ExpressionInput label="r_min" value={d.r_min} step={0.5} onChange={(v) => update(id, { r_min: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="torus" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'r_maj' },
+        { id: 'in-1', label: 'r_min' },
+      ]}
+    >
+      <ExpressionInput label="r_maj" value={d.r_maj} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { r_maj: v })} />
+      <ExpressionInput label="r_min" value={d.r_min} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r_min: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/TubeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/TubeNode.tsx
@@ -7,11 +7,18 @@ export function TubeNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2TubeData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="tube" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="or" value={d.or} step={1} onChange={(v) => update(id, { or: v })} />
-      <ExpressionInput label="ir" value={d.ir} step={1} onChange={(v) => update(id, { ir: v })} />
-      <ExpressionInput label="wall" value={d.wall} step={0.5} onChange={(v) => update(id, { wall: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="tube" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'or' },
+        { id: 'in-2', label: 'ir' },
+        { id: 'in-3', label: 'wall' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="or" value={d.or} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { or: v })} />
+      <ExpressionInput label="ir" value={d.ir} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { ir: v })} />
+      <ExpressionInput label="wall" value={d.wall} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { wall: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/shapes3d/WedgeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/WedgeNode.tsx
@@ -7,10 +7,16 @@ export function WedgeNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2WedgeData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_shapes3d" label="wedge" selected={selected}>
-      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
-      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
-      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
+    <BaseNode id={id} category="bosl2_shapes3d" label="wedge" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'x' },
+        { id: 'in-1', label: 'y' },
+        { id: 'in-2', label: 'z' },
+      ]}
+    >
+      <ExpressionInput label="x" value={d.x} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { z: v })} />
     </BaseNode>
   )
 }


### PR DESCRIPTION
## Summary

- Add `inputHandles` + wired `ExpressionInput` (with `nodeId`/`handleId`) to all 14 BOSL2 shapes3d nodes (cuboid, cyl, spheroid, torus, tube, prismoid, wedge, pie_slice, teardrop, onion, rect_tube, octahedron, regular_prism, text3d)
- Update `shapes3dCodegen.ts` to use `ctx.resolveValueInput(N, ctx.expr(d.field))` so wired edges override local data at codegen time
- Fix missing `$fn` ExpressionInput in CylNode and SpheroidNode UI (type + codegen already supported it)

## Design decisions

- **Checkboxes/Selects** (circum, style) — no handles, matching base primitive pattern
- **TextInputs** (text, font on text3d) — no handles, component lacks handle support
- Handle IDs are sequential `in-0`, `in-1`, ... matching UI order of ExpressionInputs

## Test plan

- [x] `npm test` — 268 unit tests pass (includes existing codegen tests)
- [ ] Visual check — each BOSL2 node shows left-side input handles
- [ ] Wire test — connect parameter node to BOSL2 input, verify codegen uses variable name

🤖 Generated with [Claude Code](https://claude.com/claude-code)