### PR TITLE
feat: add input edges/handles to BOSL2 rounding & sweep nodes

### DIFF
--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -1787,26 +1787,26 @@ describe("BOSL2 Codegen Handlers", () => {
   // ─── resolveValueInput index assertions for rounding/sweeps ─────────────────
 
   describe('rounding/sweeps – resolveValueInput index assertions', () => {
-    it('offset_sweep – indices 0=height, 1=top_r, 2=bot_r', () => {
+    it('offset_sweep – in-0=child, in-1=height, in-2=top_r, in-3=bot_r', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_offset_sweep', { height: 10, top_r: 1, bot_r: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_offset_sweep(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '10')
-      expect(spy).toHaveBeenCalledWith(1, '1')
+      expect(spy).toHaveBeenCalledWith(1, '10')
       expect(spy).toHaveBeenCalledWith(2, '1')
+      expect(spy).toHaveBeenCalledWith(3, '1')
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
-    it('rounded_prism – indices 0=height, 1=joint_top, 2=joint_bot, 3=joint_sides', () => {
+    it('rounded_prism – in-0=child, in-1=height, in-2=joint_top, in-3=joint_bot, in-4=joint_sides', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_rounded_prism', { height: 10, joint_top: 1, joint_bot: 1, joint_sides: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_rounded_prism(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '10')
-      expect(spy).toHaveBeenCalledWith(1, '1')
+      expect(spy).toHaveBeenCalledWith(1, '10')
       expect(spy).toHaveBeenCalledWith(2, '1')
       expect(spy).toHaveBeenCalledWith(3, '1')
+      expect(spy).toHaveBeenCalledWith(4, '1')
       expect(spy).toHaveBeenCalledTimes(4)
     })
 
@@ -1819,44 +1819,44 @@ describe("BOSL2 Codegen Handlers", () => {
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('linear_sweep – indices 0=height, 1=twist, 2=scale, 3=slices', () => {
+    it('linear_sweep – in-0=child, in-1=height, in-2=twist, in-3=scale, in-4=slices', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_linear_sweep', { height: 20, twist: 90, scale: 0.5, slices: 40, center: true, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_linear_sweep(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '20')
-      expect(spy).toHaveBeenCalledWith(1, '90')
-      expect(spy).toHaveBeenCalledWith(2, '0.5')
-      expect(spy).toHaveBeenCalledWith(3, '40')
+      expect(spy).toHaveBeenCalledWith(1, '20')
+      expect(spy).toHaveBeenCalledWith(2, '90')
+      expect(spy).toHaveBeenCalledWith(3, '0.5')
+      expect(spy).toHaveBeenCalledWith(4, '40')
       expect(spy).toHaveBeenCalledTimes(4)
     })
 
-    it('rotate_sweep – index 0=angle', () => {
+    it('rotate_sweep – in-0=child, in-1=angle', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_rotate_sweep', { angle: 180, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_rotate_sweep(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '180')
+      expect(spy).toHaveBeenCalledWith(1, '180')
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('path_sweep – index 0=twist', () => {
+    it('path_sweep – in-0=child, in-1=twist', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_path_sweep', { method: 'incremental', twist: 180, closed: false, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_path_sweep(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '180')
+      expect(spy).toHaveBeenCalledWith(1, '180')
       expect(spy).toHaveBeenCalledTimes(1)
     })
 
-    it('spiral_sweep – indices 0=h, 1=r, 2=turns', () => {
+    it('spiral_sweep – in-0=child, in-1=h, in-2=r, in-3=turns', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_spiral_sweep', { h: 20, r: 10, turns: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
       roundingCodegen.bosl2_spiral_sweep(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '20')
-      expect(spy).toHaveBeenCalledWith(1, '10')
-      expect(spy).toHaveBeenCalledWith(2, '3')
+      expect(spy).toHaveBeenCalledWith(1, '20')
+      expect(spy).toHaveBeenCalledWith(2, '10')
+      expect(spy).toHaveBeenCalledWith(3, '3')
       expect(spy).toHaveBeenCalledTimes(3)
     })
 
@@ -1880,12 +1880,12 @@ describe("BOSL2 Codegen Handlers", () => {
       expect(spy).toHaveBeenCalledTimes(2)
     })
 
-    it('stroke – index 0=width', () => {
+    it('stroke – in-0=child, in-1=width', () => {
       const spy = vi.fn((_index: number, fallback: string) => fallback)
       const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
       const node = mockNode('bosl2_stroke', { width: 2, closed: false, endcaps: 'butt' })
       roundingCodegen.bosl2_stroke(node, ctx)
-      expect(spy).toHaveBeenCalledWith(0, '2')
+      expect(spy).toHaveBeenCalledWith(1, '2')
       expect(spy).toHaveBeenCalledTimes(1)
     })
 

--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -1784,6 +1784,123 @@ describe("BOSL2 Codegen Handlers", () => {
     });
   });
 
+  // ─── resolveValueInput index assertions for rounding/sweeps ─────────────────
+
+  describe('rounding/sweeps – resolveValueInput index assertions', () => {
+    it('offset_sweep – indices 0=height, 1=top_r, 2=bot_r', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_offset_sweep', { height: 10, top_r: 1, bot_r: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_offset_sweep(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '1')
+      expect(spy).toHaveBeenCalledWith(2, '1')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('rounded_prism – indices 0=height, 1=joint_top, 2=joint_bot, 3=joint_sides', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_rounded_prism', { height: 10, joint_top: 1, joint_bot: 1, joint_sides: 1, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_rounded_prism(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '1')
+      expect(spy).toHaveBeenCalledWith(2, '1')
+      expect(spy).toHaveBeenCalledWith(3, '1')
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
+
+    it('skin – index 0=slices', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_skin', { shapes: '[]', slices: 20, method: 'reindex', style: 'min_edge' })
+      roundingCodegen.bosl2_skin(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('linear_sweep – indices 0=height, 1=twist, 2=scale, 3=slices', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_linear_sweep', { height: 20, twist: 90, scale: 0.5, slices: 40, center: true, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_linear_sweep(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledWith(1, '90')
+      expect(spy).toHaveBeenCalledWith(2, '0.5')
+      expect(spy).toHaveBeenCalledWith(3, '40')
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
+
+    it('rotate_sweep – index 0=angle', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_rotate_sweep', { angle: 180, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_rotate_sweep(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '180')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('path_sweep – index 0=twist', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_path_sweep', { method: 'incremental', twist: 180, closed: false, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_path_sweep(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '180')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('spiral_sweep – indices 0=h, 1=r, 2=turns', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_spiral_sweep', { h: 20, r: 10, turns: 3, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_spiral_sweep(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '20')
+      expect(spy).toHaveBeenCalledWith(1, '10')
+      expect(spy).toHaveBeenCalledWith(2, '3')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+
+    it('rounding_edge_mask – indices 0=h, 1=r', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_rounding_edge_mask', { h: 10, r: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_rounding_edge_mask(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '2')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('chamfer_edge_mask – indices 0=h, 1=chamfer', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_chamfer_edge_mask', { h: 10, chamfer: 2, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_chamfer_edge_mask(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '2')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('stroke – index 0=width', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_stroke', { width: 2, closed: false, endcaps: 'butt' })
+      roundingCodegen.bosl2_stroke(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '2')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('fillet – indices 0=h, 1=r, 2=ang', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_fillet', { h: 10, r: 3, ang: 45, anchor: 'CENTER', spin: 0, orient: 'UP' })
+      roundingCodegen.bosl2_fillet(node, ctx)
+      expect(spy).toHaveBeenCalledWith(0, '10')
+      expect(spy).toHaveBeenCalledWith(1, '3')
+      expect(spy).toHaveBeenCalledWith(2, '45')
+      expect(spy).toHaveBeenCalledTimes(3)
+    })
+  })
+
   // ═══════════════════════════════════════════════════════════════════════════════
   // Tier 5: Mechanical Parts
   // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/nodepacks/bosl2/codegen/roundingCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/roundingCodegen.ts
@@ -7,21 +7,21 @@ import { anchorParams3d, optAnchor } from './utils'
 export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
   bosl2_offset_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    const heightE = ctx.resolveValueInput(1, ctx.expr(d.height))
     let params = `height = ${heightE}`
-    const top = ctx.resolveValueInput(1, ctx.expr(d.top_r)); if (top !== '0') params += `, top = os_circle(r = ${top})`
-    const bot = ctx.resolveValueInput(2, ctx.expr(d.bot_r)); if (bot !== '0') params += `, bottom = os_circle(r = ${bot})`
+    const top = ctx.resolveValueInput(2, ctx.expr(d.top_r)); if (top !== '0') params += `, top = os_circle(r = ${top})`
+    const bot = ctx.resolveValueInput(3, ctx.expr(d.bot_r)); if (bot !== '0') params += `, bottom = os_circle(r = ${bot})`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`offset_sweep(${params})`)
   },
 
   bosl2_rounded_prism: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    const heightE = ctx.resolveValueInput(1, ctx.expr(d.height))
     let params = `height = ${heightE}`
-    const jt = ctx.resolveValueInput(1, ctx.expr(d.joint_top)); if (jt !== '0') params += `, joint_top = ${jt}`
-    const jb = ctx.resolveValueInput(2, ctx.expr(d.joint_bot)); if (jb !== '0') params += `, joint_bot = ${jb}`
-    const js = ctx.resolveValueInput(3, ctx.expr(d.joint_sides)); if (js !== '0') params += `, joint_sides = ${js}`
+    const jt = ctx.resolveValueInput(2, ctx.expr(d.joint_top)); if (jt !== '0') params += `, joint_top = ${jt}`
+    const jb = ctx.resolveValueInput(3, ctx.expr(d.joint_bot)); if (jb !== '0') params += `, joint_bot = ${jb}`
+    const js = ctx.resolveValueInput(4, ctx.expr(d.joint_sides)); if (js !== '0') params += `, joint_sides = ${js}`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`rounded_prism(${params})`)
   },
@@ -40,11 +40,11 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_linear_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    const heightE = ctx.resolveValueInput(1, ctx.expr(d.height))
     let params = `height = ${heightE}`
-    const tw = ctx.resolveValueInput(1, ctx.expr(d.twist)); if (tw !== '0') params += `, twist = ${tw}`
-    const sc = ctx.resolveValueInput(2, ctx.expr(d.scale)); if (sc !== '1') params += `, scale = ${sc}`
-    const sl = ctx.resolveValueInput(3, ctx.expr(d.slices)); if (sl !== '0') params += `, slices = ${sl}`
+    const tw = ctx.resolveValueInput(2, ctx.expr(d.twist)); if (tw !== '0') params += `, twist = ${tw}`
+    const sc = ctx.resolveValueInput(3, ctx.expr(d.scale)); if (sc !== '1') params += `, scale = ${sc}`
+    const sl = ctx.resolveValueInput(4, ctx.expr(d.slices)); if (sl !== '0') params += `, slices = ${sl}`
     if (d.center) params += `, center = true`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`linear_sweep(${params})`)
@@ -53,7 +53,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
   bosl2_rotate_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
     const parts: string[] = []
-    const ang = ctx.resolveValueInput(0, ctx.expr(d.angle)); if (ang !== '360') parts.push(`angle = ${ang}`)
+    const ang = ctx.resolveValueInput(1, ctx.expr(d.angle)); if (ang !== '360') parts.push(`angle = ${ang}`)
     parts.push(...anchorParams3d(ctx, d))
     return ctx.emitTransform(`rotate_sweep(${parts.join(', ')})`)
   },
@@ -63,7 +63,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
     const parts: string[] = []
     const method = String(d.method ?? 'incremental')
     if (method !== 'incremental') parts.push(`method = "${method}"`)
-    const tw = ctx.resolveValueInput(0, ctx.expr(d.twist)); if (tw !== '0') parts.push(`twist = ${tw}`)
+    const tw = ctx.resolveValueInput(1, ctx.expr(d.twist)); if (tw !== '0') parts.push(`twist = ${tw}`)
     if (d.closed) parts.push(`closed = true`)
     parts.push(...anchorParams3d(ctx, d))
     return ctx.emitTransform(`path_sweep(${parts.join(', ')})`)
@@ -71,9 +71,9 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_spiral_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const hE = ctx.resolveValueInput(0, ctx.expr(d.h))
-    const rE = ctx.resolveValueInput(1, ctx.expr(d.r))
-    const turnsE = ctx.resolveValueInput(2, ctx.expr(d.turns))
+    const hE = ctx.resolveValueInput(1, ctx.expr(d.h))
+    const rE = ctx.resolveValueInput(2, ctx.expr(d.r))
+    const turnsE = ctx.resolveValueInput(3, ctx.expr(d.turns))
     let params = `h = ${hE}, r = ${rE}, turns = ${turnsE}`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`spiral_sweep(${params})`)
@@ -115,7 +115,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_stroke: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const widthE = ctx.resolveValueInput(0, ctx.expr(d.width))
+    const widthE = ctx.resolveValueInput(1, ctx.expr(d.width))
     let params = `width = ${widthE}`
     if (d.closed) params += `, closed = true`
     const ec = String(d.endcaps ?? '')

--- a/src/nodepacks/bosl2/codegen/roundingCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/roundingCodegen.ts
@@ -7,19 +7,21 @@ import { anchorParams3d, optAnchor } from './utils'
 export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) => string> = {
   bosl2_offset_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `height = ${ctx.expr(d.height)}`
-    const top = ctx.expr(d.top_r); if (top !== '0') params += `, top = os_circle(r = ${top})`
-    const bot = ctx.expr(d.bot_r); if (bot !== '0') params += `, bottom = os_circle(r = ${bot})`
+    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    let params = `height = ${heightE}`
+    const top = ctx.resolveValueInput(1, ctx.expr(d.top_r)); if (top !== '0') params += `, top = os_circle(r = ${top})`
+    const bot = ctx.resolveValueInput(2, ctx.expr(d.bot_r)); if (bot !== '0') params += `, bottom = os_circle(r = ${bot})`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`offset_sweep(${params})`)
   },
 
   bosl2_rounded_prism: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `height = ${ctx.expr(d.height)}`
-    const jt = ctx.expr(d.joint_top); if (jt !== '0') params += `, joint_top = ${jt}`
-    const jb = ctx.expr(d.joint_bot); if (jb !== '0') params += `, joint_bot = ${jb}`
-    const js = ctx.expr(d.joint_sides); if (js !== '0') params += `, joint_sides = ${js}`
+    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    let params = `height = ${heightE}`
+    const jt = ctx.resolveValueInput(1, ctx.expr(d.joint_top)); if (jt !== '0') params += `, joint_top = ${jt}`
+    const jb = ctx.resolveValueInput(2, ctx.expr(d.joint_bot)); if (jb !== '0') params += `, joint_bot = ${jb}`
+    const js = ctx.resolveValueInput(3, ctx.expr(d.joint_sides)); if (js !== '0') params += `, joint_sides = ${js}`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`rounded_prism(${params})`)
   },
@@ -28,7 +30,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
     const d = node.data as Record<string, unknown>
     const shapes = String(d.shapes ?? '[]')
     const parts: string[] = [shapes]
-    const sl = ctx.expr(d.slices); if (sl !== '0' && sl !== '10') parts.push(`slices = ${sl}`)
+    const sl = ctx.resolveValueInput(0, ctx.expr(d.slices)); if (sl !== '0' && sl !== '10') parts.push(`slices = ${sl}`)
     const method = String(d.method ?? 'reindex')
     if (method !== 'reindex') parts.push(`method = "${method}"`)
     const style = String(d.style ?? 'min_edge')
@@ -38,10 +40,11 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_linear_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `height = ${ctx.expr(d.height)}`
-    const tw = ctx.expr(d.twist); if (tw !== '0') params += `, twist = ${tw}`
-    const sc = ctx.expr(d.scale); if (sc !== '1') params += `, scale = ${sc}`
-    const sl = ctx.expr(d.slices); if (sl !== '0') params += `, slices = ${sl}`
+    const heightE = ctx.resolveValueInput(0, ctx.expr(d.height))
+    let params = `height = ${heightE}`
+    const tw = ctx.resolveValueInput(1, ctx.expr(d.twist)); if (tw !== '0') params += `, twist = ${tw}`
+    const sc = ctx.resolveValueInput(2, ctx.expr(d.scale)); if (sc !== '1') params += `, scale = ${sc}`
+    const sl = ctx.resolveValueInput(3, ctx.expr(d.slices)); if (sl !== '0') params += `, slices = ${sl}`
     if (d.center) params += `, center = true`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`linear_sweep(${params})`)
@@ -50,7 +53,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
   bosl2_rotate_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
     const parts: string[] = []
-    const ang = ctx.expr(d.angle); if (ang !== '360') parts.push(`angle = ${ang}`)
+    const ang = ctx.resolveValueInput(0, ctx.expr(d.angle)); if (ang !== '360') parts.push(`angle = ${ang}`)
     parts.push(...anchorParams3d(ctx, d))
     return ctx.emitTransform(`rotate_sweep(${parts.join(', ')})`)
   },
@@ -60,7 +63,7 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
     const parts: string[] = []
     const method = String(d.method ?? 'incremental')
     if (method !== 'incremental') parts.push(`method = "${method}"`)
-    const tw = ctx.expr(d.twist); if (tw !== '0') parts.push(`twist = ${tw}`)
+    const tw = ctx.resolveValueInput(0, ctx.expr(d.twist)); if (tw !== '0') parts.push(`twist = ${tw}`)
     if (d.closed) parts.push(`closed = true`)
     parts.push(...anchorParams3d(ctx, d))
     return ctx.emitTransform(`path_sweep(${parts.join(', ')})`)
@@ -68,7 +71,10 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_spiral_sweep: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}, turns = ${ctx.expr(d.turns)}`
+    const hE = ctx.resolveValueInput(0, ctx.expr(d.h))
+    const rE = ctx.resolveValueInput(1, ctx.expr(d.r))
+    const turnsE = ctx.resolveValueInput(2, ctx.expr(d.turns))
+    let params = `h = ${hE}, r = ${rE}, turns = ${turnsE}`
     params += optAnchor(ctx, d)
     return ctx.emitTransform(`spiral_sweep(${params})`)
   },
@@ -91,21 +97,26 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_rounding_edge_mask: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
+    const hE = ctx.resolveValueInput(0, ctx.expr(d.h))
+    const rE = ctx.resolveValueInput(1, ctx.expr(d.r))
+    let params = `h = ${hE}, r = ${rE}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}rounding_edge_mask(${params});\n`
   },
 
   bosl2_chamfer_edge_mask: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, chamfer = ${ctx.expr(d.chamfer)}`
+    const hE = ctx.resolveValueInput(0, ctx.expr(d.h))
+    const chamferE = ctx.resolveValueInput(1, ctx.expr(d.chamfer))
+    let params = `h = ${hE}, chamfer = ${chamferE}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}chamfer_edge_mask(${params});\n`
   },
 
   bosl2_stroke: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `width = ${ctx.expr(d.width)}`
+    const widthE = ctx.resolveValueInput(0, ctx.expr(d.width))
+    let params = `width = ${widthE}`
     if (d.closed) params += `, closed = true`
     const ec = String(d.endcaps ?? '')
     if (ec && ec !== 'butt') params += `, endcaps = "${ec}"`
@@ -114,8 +125,10 @@ export const roundingCodegen: Record<string, (node: Node, ctx: CodegenContext) =
 
   bosl2_fillet: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    let params = `h = ${ctx.expr(d.h)}, r = ${ctx.expr(d.r)}`
-    const ang = ctx.expr(d.ang); if (ang !== '90') params += `, ang = ${ang}`
+    const hE = ctx.resolveValueInput(0, ctx.expr(d.h))
+    const rE = ctx.resolveValueInput(1, ctx.expr(d.r))
+    let params = `h = ${hE}, r = ${rE}`
+    const ang = ctx.resolveValueInput(2, ctx.expr(d.ang)); if (ang !== '90') params += `, ang = ${ang}`
     params += optAnchor(ctx, d)
     return `${ctx.pad}fillet(${params});\n`
   },

--- a/src/nodepacks/bosl2/nodes/rounding/ChamferEdgeMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/ChamferEdgeMaskNode.tsx
@@ -7,9 +7,14 @@ export function ChamferEdgeMaskNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2ChamferEdgeMaskData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="chamfer_edge_mask" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} onChange={(v) => update(id, { chamfer: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="chamfer_edge_mask" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'chamfer' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="chamfer" value={d.chamfer} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { chamfer: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
@@ -7,11 +7,18 @@ export function LinearSweepNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2LinearSweepData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="linear_sweep" selected={selected}>
-      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="twist" value={d.twist} step={1} onChange={(v) => update(id, { twist: v })} />
-      <ExpressionInput label="scale" value={d.scale} step={0.1} onChange={(v) => update(id, { scale: v })} />
-      <ExpressionInput label="slices" value={d.slices} step={1} onChange={(v) => update(id, { slices: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="linear_sweep" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'height' },
+        { id: 'in-1', label: 'twist' },
+        { id: 'in-2', label: 'scale' },
+        { id: 'in-3', label: 'slices' },
+      ]}
+    >
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { twist: v })} />
+      <ExpressionInput label="scale" value={d.scale} step={0.1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { scale: v })} />
+      <ExpressionInput label="slices" value={d.slices} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { slices: v })} />
       <CheckboxInput label="center" value={d.center} onChange={(v) => update(id, { center: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/LinearSweepNode.tsx
@@ -9,16 +9,17 @@ export function LinearSweepNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="linear_sweep" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'height' },
-        { id: 'in-1', label: 'twist' },
-        { id: 'in-2', label: 'scale' },
-        { id: 'in-3', label: 'slices' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'height' },
+        { id: 'in-2', label: 'twist' },
+        { id: 'in-3', label: 'scale' },
+        { id: 'in-4', label: 'slices' },
       ]}
     >
-      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { twist: v })} />
-      <ExpressionInput label="scale" value={d.scale} step={0.1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { scale: v })} />
-      <ExpressionInput label="slices" value={d.slices} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { slices: v })} />
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { twist: v })} />
+      <ExpressionInput label="scale" value={d.scale} step={0.1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { scale: v })} />
+      <ExpressionInput label="slices" value={d.slices} step={1} nodeId={id} handleId="in-4" onChange={(v) => update(id, { slices: v })} />
       <CheckboxInput label="center" value={d.center} onChange={(v) => update(id, { center: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
@@ -7,10 +7,16 @@ export function OffsetSweepNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2OffsetSweepData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="offset_sweep" selected={selected}>
-      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="top_r" value={d.top_r} step={0.5} onChange={(v) => update(id, { top_r: v })} />
-      <ExpressionInput label="bot_r" value={d.bot_r} step={0.5} onChange={(v) => update(id, { bot_r: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="offset_sweep" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'height' },
+        { id: 'in-1', label: 'top_r' },
+        { id: 'in-2', label: 'bot_r' },
+      ]}
+    >
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="top_r" value={d.top_r} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { top_r: v })} />
+      <ExpressionInput label="bot_r" value={d.bot_r} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { bot_r: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/OffsetSweepNode.tsx
@@ -9,14 +9,15 @@ export function OffsetSweepNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="offset_sweep" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'height' },
-        { id: 'in-1', label: 'top_r' },
-        { id: 'in-2', label: 'bot_r' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'height' },
+        { id: 'in-2', label: 'top_r' },
+        { id: 'in-3', label: 'bot_r' },
       ]}
     >
-      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="top_r" value={d.top_r} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { top_r: v })} />
-      <ExpressionInput label="bot_r" value={d.bot_r} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { bot_r: v })} />
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="top_r" value={d.top_r} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { top_r: v })} />
+      <ExpressionInput label="bot_r" value={d.bot_r} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { bot_r: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
@@ -9,11 +9,12 @@ export function PathSweepNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="path_sweep" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'twist' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'twist' },
       ]}
     >
       <SelectInput label="method" value={d.method} options={["incremental", "manual", "natural"]} onChange={(v) => update(id, { method: v })} />
-      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { twist: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { twist: v })} />
       <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/PathSweepNode.tsx
@@ -7,9 +7,13 @@ export function PathSweepNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2PathSweepData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="path_sweep" selected={selected}>
+    <BaseNode id={id} category="bosl2_rounding" label="path_sweep" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'twist' },
+      ]}
+    >
       <SelectInput label="method" value={d.method} options={["incremental", "manual", "natural"]} onChange={(v) => update(id, { method: v })} />
-      <ExpressionInput label="twist" value={d.twist} step={1} onChange={(v) => update(id, { twist: v })} />
+      <ExpressionInput label="twist" value={d.twist} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { twist: v })} />
       <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
     </BaseNode>
   )

--- a/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
@@ -7,8 +7,12 @@ export function RotateSweepNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RotateSweepData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="rotate_sweep" selected={selected}>
-      <ExpressionInput label="angle" value={d.angle} step={1} onChange={(v) => update(id, { angle: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="rotate_sweep" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'angle' },
+      ]}
+    >
+      <ExpressionInput label="angle" value={d.angle} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { angle: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RotateSweepNode.tsx
@@ -9,10 +9,11 @@ export function RotateSweepNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="rotate_sweep" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'angle' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'angle' },
       ]}
     >
-      <ExpressionInput label="angle" value={d.angle} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { angle: v })} />
+      <ExpressionInput label="angle" value={d.angle} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { angle: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
@@ -9,16 +9,17 @@ export function RoundedPrismNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="rounded_prism" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'height' },
-        { id: 'in-1', label: 'joint_top' },
-        { id: 'in-2', label: 'joint_bot' },
-        { id: 'in-3', label: 'joint_sides' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'height' },
+        { id: 'in-2', label: 'joint_top' },
+        { id: 'in-3', label: 'joint_bot' },
+        { id: 'in-4', label: 'joint_sides' },
       ]}
     >
-      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="joint_top" value={d.joint_top} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { joint_top: v })} />
-      <ExpressionInput label="joint_bot" value={d.joint_bot} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { joint_bot: v })} />
-      <ExpressionInput label="joint_sides" value={d.joint_sides} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { joint_sides: v })} />
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="joint_top" value={d.joint_top} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { joint_top: v })} />
+      <ExpressionInput label="joint_bot" value={d.joint_bot} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { joint_bot: v })} />
+      <ExpressionInput label="joint_sides" value={d.joint_sides} step={0.5} nodeId={id} handleId="in-4" onChange={(v) => update(id, { joint_sides: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RoundedPrismNode.tsx
@@ -7,11 +7,18 @@ export function RoundedPrismNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RoundedPrismData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="rounded_prism" selected={selected}>
-      <ExpressionInput label="height" value={d.height} step={1} onChange={(v) => update(id, { height: v })} />
-      <ExpressionInput label="joint_top" value={d.joint_top} step={0.5} onChange={(v) => update(id, { joint_top: v })} />
-      <ExpressionInput label="joint_bot" value={d.joint_bot} step={0.5} onChange={(v) => update(id, { joint_bot: v })} />
-      <ExpressionInput label="joint_sides" value={d.joint_sides} step={0.5} onChange={(v) => update(id, { joint_sides: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="rounded_prism" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'height' },
+        { id: 'in-1', label: 'joint_top' },
+        { id: 'in-2', label: 'joint_bot' },
+        { id: 'in-3', label: 'joint_sides' },
+      ]}
+    >
+      <ExpressionInput label="height" value={d.height} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { height: v })} />
+      <ExpressionInput label="joint_top" value={d.joint_top} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { joint_top: v })} />
+      <ExpressionInput label="joint_bot" value={d.joint_bot} step={0.5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { joint_bot: v })} />
+      <ExpressionInput label="joint_sides" value={d.joint_sides} step={0.5} nodeId={id} handleId="in-3" onChange={(v) => update(id, { joint_sides: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/RoundingEdgeMaskNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/RoundingEdgeMaskNode.tsx
@@ -7,9 +7,14 @@ export function RoundingEdgeMaskNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2RoundingEdgeMaskData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="rounding_edge_mask" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={0.5} onChange={(v) => update(id, { r: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="rounding_edge_mask" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/SkinNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/SkinNode.tsx
@@ -7,9 +7,13 @@ export function SkinNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2SkinData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="skin" selected={selected}>
+    <BaseNode id={id} category="bosl2_rounding" label="skin" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'slices' },
+      ]}
+    >
       <TextInput label="shapes" value={d.shapes} onChange={(v) => update(id, { shapes: v })} />
-      <ExpressionInput label="slices" value={d.slices} step={1} onChange={(v) => update(id, { slices: v })} />
+      <ExpressionInput label="slices" value={d.slices} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { slices: v })} />
       <SelectInput label="method" value={d.method} options={["reindex", "distance", "fast_distance", "tangent"]} onChange={(v) => update(id, { method: v })} />
       <SelectInput label="style" value={d.style} options={["min_edge", "quincunx", "alt_tri", "tri"]} onChange={(v) => update(id, { style: v })} />
     </BaseNode>

--- a/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
@@ -7,10 +7,16 @@ export function SpiralSweepNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2SpiralSweepData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="spiral_sweep" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="turns" value={d.turns} step={1} onChange={(v) => update(id, { turns: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="spiral_sweep" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+        { id: 'in-2', label: 'turns' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="turns" value={d.turns} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { turns: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/SpiralSweepNode.tsx
@@ -9,14 +9,15 @@ export function SpiralSweepNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="spiral_sweep" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'h' },
-        { id: 'in-1', label: 'r' },
-        { id: 'in-2', label: 'turns' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'h' },
+        { id: 'in-2', label: 'r' },
+        { id: 'in-3', label: 'turns' },
       ]}
     >
-      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="turns" value={d.turns} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { turns: v })} />
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="turns" value={d.turns} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { turns: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
@@ -7,8 +7,12 @@ export function StrokeNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2StrokeData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="stroke" selected={selected}>
-      <ExpressionInput label="width" value={d.width} step={0.5} onChange={(v) => update(id, { width: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="stroke" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'width' },
+      ]}
+    >
+      <ExpressionInput label="width" value={d.width} step={0.5} nodeId={id} handleId="in-0" onChange={(v) => update(id, { width: v })} />
       <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
       <SelectInput label="endcaps" value={d.endcaps} options={["butt", "round", "square", "line", "tail"]} onChange={(v) => update(id, { endcaps: v })} />
     </BaseNode>

--- a/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
+++ b/src/nodepacks/bosl2/nodes/rounding/StrokeNode.tsx
@@ -9,10 +9,11 @@ export function StrokeNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_rounding" label="stroke" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'width' },
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'width' },
       ]}
     >
-      <ExpressionInput label="width" value={d.width} step={0.5} nodeId={id} handleId="in-0" onChange={(v) => update(id, { width: v })} />
+      <ExpressionInput label="width" value={d.width} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { width: v })} />
       <CheckboxInput label="closed" value={d.closed} onChange={(v) => update(id, { closed: v })} />
       <SelectInput label="endcaps" value={d.endcaps} options={["butt", "round", "square", "line", "tail"]} onChange={(v) => update(id, { endcaps: v })} />
     </BaseNode>

--- a/src/nodepacks/bosl2/nodes/shapes3d/FilletNode.tsx
+++ b/src/nodepacks/bosl2/nodes/shapes3d/FilletNode.tsx
@@ -7,10 +7,16 @@ export function FilletNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2FilletData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_rounding" label="fillet" selected={selected}>
-      <ExpressionInput label="h" value={d.h} step={1} onChange={(v) => update(id, { h: v })} />
-      <ExpressionInput label="r" value={d.r} step={0.5} onChange={(v) => update(id, { r: v })} />
-      <ExpressionInput label="ang" value={d.ang} step={5} onChange={(v) => update(id, { ang: v })} />
+    <BaseNode id={id} category="bosl2_rounding" label="fillet" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'h' },
+        { id: 'in-1', label: 'r' },
+        { id: 'in-2', label: 'ang' },
+      ]}
+    >
+      <ExpressionInput label="h" value={d.h} step={1} nodeId={id} handleId="in-0" onChange={(v) => update(id, { h: v })} />
+      <ExpressionInput label="r" value={d.r} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { r: v })} />
+      <ExpressionInput label="ang" value={d.ang} step={5} nodeId={id} handleId="in-2" onChange={(v) => update(id, { ang: v })} />
     </BaseNode>
   )
 }


### PR DESCRIPTION
- Add inputHandles prop and nodeId/handleId to ExpressionInput on 11 rounding/sweep nodes: OffsetSweep, RoundedPrism, Skin, LinearSweep, RotateSweep, PathSweep, SpiralSweep, RoundingEdgeMask, ChamferEdgeMask, Stroke, Fillet
- Update roundingCodegen to use ctx.resolveValueInput() for all numeric parameters, enabling value-edge connections
- Add resolveValueInput index assertion tests for all 11 handlers
- CornerMask and EdgeMask unchanged (TextInput only, no numeric inputs)