### PR TITLE
feat: add input edges to BOSL2 attachment nodes

### DIFF
--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -2671,6 +2671,43 @@ describe("BOSL2 Codegen Handlers", () => {
       expect(result).not.toContain("spread");
       expect(result).not.toContain("cutpath");
     });
+
+    // ─── resolveValueInput index assertions for attachments ───────────────────
+
+    it('attach – resolveValueInput called with correct index (1=overlap)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_attach', { parent: 'TOP', child: 'BOT', overlap: 0.5 })
+      attachmentsCodegen.bosl2_attach(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '0.5')
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('half_of – resolveValueInput called with correct indices (1=vx, 2=vy, 3=vz, 4=cpx, 5=cpy, 6=cpz)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_half_of', { vx: 0, vy: 0, vz: 1, cpx: 5, cpy: 3, cpz: 1 })
+      attachmentsCodegen.bosl2_half_of(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '0')   // vx
+      expect(spy).toHaveBeenCalledWith(2, '0')   // vy
+      expect(spy).toHaveBeenCalledWith(3, '1')   // vz
+      expect(spy).toHaveBeenCalledWith(4, '5')   // cpx
+      expect(spy).toHaveBeenCalledWith(5, '3')   // cpy
+      expect(spy).toHaveBeenCalledWith(6, '1')   // cpz
+      expect(spy).toHaveBeenCalledTimes(6)
+    })
+
+    it('partition – resolveValueInput called with correct indices (1=x, 2=y, 3=z, 4=spread)', () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback)
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
+      const node = mockNode('bosl2_partition', { x: 100, y: 100, z: 100, spread: 10, cutpath: 'jigsaw' })
+      attachmentsCodegen.bosl2_partition(node, ctx)
+      expect(spy).toHaveBeenCalledWith(1, '100')  // x
+      expect(spy).toHaveBeenCalledWith(2, '100')  // y
+      expect(spy).toHaveBeenCalledWith(3, '100')  // z
+      expect(spy).toHaveBeenCalledWith(4, '10')   // spread
+      expect(spy).toHaveBeenCalledTimes(4)
+    })
   });
 
   // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/nodepacks/bosl2/__tests__/codegen.test.ts
+++ b/src/nodepacks/bosl2/__tests__/codegen.test.ts
@@ -2674,40 +2674,40 @@ describe("BOSL2 Codegen Handlers", () => {
 
     // ─── resolveValueInput index assertions for attachments ───────────────────
 
-    it('attach – resolveValueInput called with correct index (1=overlap)', () => {
-      const spy = vi.fn((_index: number, fallback: string) => fallback)
-      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
-      const node = mockNode('bosl2_attach', { parent: 'TOP', child: 'BOT', overlap: 0.5 })
-      attachmentsCodegen.bosl2_attach(node, ctx)
-      expect(spy).toHaveBeenCalledWith(1, '0.5')
-      expect(spy).toHaveBeenCalledTimes(1)
-    })
+    it("attach – resolveValueInput called with correct index (1=overlap)", () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback);
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy };
+      const node = mockNode("bosl2_attach", { parent: "TOP", child: "BOT", overlap: 0.5 });
+      attachmentsCodegen.bosl2_attach(node, ctx);
+      expect(spy).toHaveBeenCalledWith(1, "0.5");
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
 
-    it('half_of – resolveValueInput called with correct indices (1=vx, 2=vy, 3=vz, 4=cpx, 5=cpy, 6=cpz)', () => {
-      const spy = vi.fn((_index: number, fallback: string) => fallback)
-      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
-      const node = mockNode('bosl2_half_of', { vx: 0, vy: 0, vz: 1, cpx: 5, cpy: 3, cpz: 1 })
-      attachmentsCodegen.bosl2_half_of(node, ctx)
-      expect(spy).toHaveBeenCalledWith(1, '0')   // vx
-      expect(spy).toHaveBeenCalledWith(2, '0')   // vy
-      expect(spy).toHaveBeenCalledWith(3, '1')   // vz
-      expect(spy).toHaveBeenCalledWith(4, '5')   // cpx
-      expect(spy).toHaveBeenCalledWith(5, '3')   // cpy
-      expect(spy).toHaveBeenCalledWith(6, '1')   // cpz
-      expect(spy).toHaveBeenCalledTimes(6)
-    })
+    it("half_of – resolveValueInput called with correct indices (1=vx, 2=vy, 3=vz, 4=cpx, 5=cpy, 6=cpz)", () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback);
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy };
+      const node = mockNode("bosl2_half_of", { vx: 0, vy: 0, vz: 1, cpx: 5, cpy: 3, cpz: 1 });
+      attachmentsCodegen.bosl2_half_of(node, ctx);
+      expect(spy).toHaveBeenCalledWith(1, "0");   // vx
+      expect(spy).toHaveBeenCalledWith(2, "0");   // vy
+      expect(spy).toHaveBeenCalledWith(3, "1");   // vz
+      expect(spy).toHaveBeenCalledWith(4, "5");   // cpx
+      expect(spy).toHaveBeenCalledWith(5, "3");   // cpy
+      expect(spy).toHaveBeenCalledWith(6, "1");   // cpz
+      expect(spy).toHaveBeenCalledTimes(6);
+    });
 
-    it('partition – resolveValueInput called with correct indices (1=x, 2=y, 3=z, 4=spread)', () => {
-      const spy = vi.fn((_index: number, fallback: string) => fallback)
-      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy }
-      const node = mockNode('bosl2_partition', { x: 100, y: 100, z: 100, spread: 10, cutpath: 'jigsaw' })
-      attachmentsCodegen.bosl2_partition(node, ctx)
-      expect(spy).toHaveBeenCalledWith(1, '100')  // x
-      expect(spy).toHaveBeenCalledWith(2, '100')  // y
-      expect(spy).toHaveBeenCalledWith(3, '100')  // z
-      expect(spy).toHaveBeenCalledWith(4, '10')   // spread
-      expect(spy).toHaveBeenCalledTimes(4)
-    })
+    it("partition – resolveValueInput called with correct indices (1=x, 2=y, 3=z, 4=spread)", () => {
+      const spy = vi.fn((_index: number, fallback: string) => fallback);
+      const ctx: CodegenContext = { ...mockCtx, resolveValueInput: spy };
+      const node = mockNode("bosl2_partition", { x: 100, y: 100, z: 100, spread: 10, cutpath: "jigsaw" });
+      attachmentsCodegen.bosl2_partition(node, ctx);
+      expect(spy).toHaveBeenCalledWith(1, "100");  // x
+      expect(spy).toHaveBeenCalledWith(2, "100");  // y
+      expect(spy).toHaveBeenCalledWith(3, "100");  // z
+      expect(spy).toHaveBeenCalledWith(4, "10");   // spread
+      expect(spy).toHaveBeenCalledTimes(4);
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/nodepacks/bosl2/codegen/attachmentsCodegen.ts
+++ b/src/nodepacks/bosl2/codegen/attachmentsCodegen.ts
@@ -33,7 +33,7 @@ export const attachmentsCodegen: Record<string, (node: Node, ctx: CodegenContext
     const parent = String(d.parent ?? 'TOP')
     const child = String(d.child ?? 'BOT')
     let params = `${parent}, ${child}`
-    const ov = ctx.expr(d.overlap); if (ov !== '0') params += `, overlap = ${ov}`
+    const ov = ctx.resolveValueInput(1, ctx.expr(d.overlap)); if (ov !== '0') params += `, overlap = ${ov}`
     return ctx.emitTransform(`attach(${params})`)
   },
 
@@ -51,8 +51,8 @@ export const attachmentsCodegen: Record<string, (node: Node, ctx: CodegenContext
 
   bosl2_half_of: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const v = `[${ctx.expr(d.vx)}, ${ctx.expr(d.vy)}, ${ctx.expr(d.vz)}]`
-    const cp = `[${ctx.expr(d.cpx)}, ${ctx.expr(d.cpy)}, ${ctx.expr(d.cpz)}]`
+    const v = `[${ctx.resolveValueInput(1, ctx.expr(d.vx))}, ${ctx.resolveValueInput(2, ctx.expr(d.vy))}, ${ctx.resolveValueInput(3, ctx.expr(d.vz))}]`
+    const cp = `[${ctx.resolveValueInput(4, ctx.expr(d.cpx))}, ${ctx.resolveValueInput(5, ctx.expr(d.cpy))}, ${ctx.resolveValueInput(6, ctx.expr(d.cpz))}]`
     let params = `${v}`
     if (cp !== '[0, 0, 0]') params += `, cp = ${cp}`
     return ctx.emitTransform(`half_of(${params})`)
@@ -60,9 +60,9 @@ export const attachmentsCodegen: Record<string, (node: Node, ctx: CodegenContext
 
   bosl2_partition: (node, ctx) => {
     const d = node.data as Record<string, unknown>
-    const size = `[${ctx.expr(d.x)}, ${ctx.expr(d.y)}, ${ctx.expr(d.z)}]`
+    const size = `[${ctx.resolveValueInput(1, ctx.expr(d.x))}, ${ctx.resolveValueInput(2, ctx.expr(d.y))}, ${ctx.resolveValueInput(3, ctx.expr(d.z))}]`
     let params = `size = ${size}`
-    const sp = ctx.expr(d.spread); if (sp !== '0') params += `, spread = ${sp}`
+    const sp = ctx.resolveValueInput(4, ctx.expr(d.spread)); if (sp !== '0') params += `, spread = ${sp}`
     const cp = String(d.cutpath ?? ''); if (cp) params += `, cutpath = "${ctx.escapeString(cp)}"`
     return ctx.emitTransform(`partition(${params})`)
   },

--- a/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
@@ -9,7 +9,7 @@ export function AttachNode({ id, data, selected }: NodeProps) {
   return (
     <BaseNode id={id} category="bosl2_attachments" label="attach" selected={selected}
       inputHandles={[
-        { id: 'in-0', label: 'child' },
+        { id: 'in-0', label: 'geom' },
         { id: 'in-1', label: 'overlap' },
       ]}
     >

--- a/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/AttachNode.tsx
@@ -7,10 +7,15 @@ export function AttachNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2AttachData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_attachments" label="attach" selected={selected}>
+    <BaseNode id={id} category="bosl2_attachments" label="attach" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'overlap' },
+      ]}
+    >
       <TextInput label="parent" value={d.parent} onChange={(v) => update(id, { parent: v })} />
       <TextInput label="child" value={d.child} onChange={(v) => update(id, { child: v })} />
-      <ExpressionInput label="overlap" value={d.overlap} step={0.5} onChange={(v) => update(id, { overlap: v })} />
+      <ExpressionInput label="overlap" value={d.overlap} step={0.5} nodeId={id} handleId="in-1" onChange={(v) => update(id, { overlap: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/attachments/HalfOfNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/HalfOfNode.tsx
@@ -7,13 +7,23 @@ export function HalfOfNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2HalfOfData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_attachments" label="half_of" selected={selected}>
-      <ExpressionInput label="vx" value={d.vx} step={1} onChange={(v) => update(id, { vx: v })} />
-      <ExpressionInput label="vy" value={d.vy} step={1} onChange={(v) => update(id, { vy: v })} />
-      <ExpressionInput label="vz" value={d.vz} step={1} onChange={(v) => update(id, { vz: v })} />
-      <ExpressionInput label="cpx" value={d.cpx} step={1} onChange={(v) => update(id, { cpx: v })} />
-      <ExpressionInput label="cpy" value={d.cpy} step={1} onChange={(v) => update(id, { cpy: v })} />
-      <ExpressionInput label="cpz" value={d.cpz} step={1} onChange={(v) => update(id, { cpz: v })} />
+    <BaseNode id={id} category="bosl2_attachments" label="half_of" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'vx' },
+        { id: 'in-2', label: 'vy' },
+        { id: 'in-3', label: 'vz' },
+        { id: 'in-4', label: 'cpx' },
+        { id: 'in-5', label: 'cpy' },
+        { id: 'in-6', label: 'cpz' },
+      ]}
+    >
+      <ExpressionInput label="vx" value={d.vx} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { vx: v })} />
+      <ExpressionInput label="vy" value={d.vy} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { vy: v })} />
+      <ExpressionInput label="vz" value={d.vz} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { vz: v })} />
+      <ExpressionInput label="cpx" value={d.cpx} step={1} nodeId={id} handleId="in-4" onChange={(v) => update(id, { cpx: v })} />
+      <ExpressionInput label="cpy" value={d.cpy} step={1} nodeId={id} handleId="in-5" onChange={(v) => update(id, { cpy: v })} />
+      <ExpressionInput label="cpz" value={d.cpz} step={1} nodeId={id} handleId="in-6" onChange={(v) => update(id, { cpz: v })} />
     </BaseNode>
   )
 }

--- a/src/nodepacks/bosl2/nodes/attachments/PartitionNode.tsx
+++ b/src/nodepacks/bosl2/nodes/attachments/PartitionNode.tsx
@@ -7,11 +7,19 @@ export function PartitionNode({ id, data, selected }: NodeProps) {
   const d = data as unknown as Bosl2PartitionData
   const update = useEditorStore((s) => s.updateNodeData)
   return (
-    <BaseNode id={id} category="bosl2_attachments" label="partition" selected={selected}>
-      <ExpressionInput label="x" value={d.x} step={1} onChange={(v) => update(id, { x: v })} />
-      <ExpressionInput label="y" value={d.y} step={1} onChange={(v) => update(id, { y: v })} />
-      <ExpressionInput label="z" value={d.z} step={1} onChange={(v) => update(id, { z: v })} />
-      <ExpressionInput label="spread" value={d.spread} step={1} onChange={(v) => update(id, { spread: v })} />
+    <BaseNode id={id} category="bosl2_attachments" label="partition" selected={selected}
+      inputHandles={[
+        { id: 'in-0', label: 'child' },
+        { id: 'in-1', label: 'x' },
+        { id: 'in-2', label: 'y' },
+        { id: 'in-3', label: 'z' },
+        { id: 'in-4', label: 'spread' },
+      ]}
+    >
+      <ExpressionInput label="x" value={d.x} step={1} nodeId={id} handleId="in-1" onChange={(v) => update(id, { x: v })} />
+      <ExpressionInput label="y" value={d.y} step={1} nodeId={id} handleId="in-2" onChange={(v) => update(id, { y: v })} />
+      <ExpressionInput label="z" value={d.z} step={1} nodeId={id} handleId="in-3" onChange={(v) => update(id, { z: v })} />
+      <ExpressionInput label="spread" value={d.spread} step={1} nodeId={id} handleId="in-4" onChange={(v) => update(id, { spread: v })} />
       <TextInput label="cutpath" value={d.cutpath} onChange={(v) => update(id, { cutpath: v })} />
     </BaseNode>
   )


### PR DESCRIPTION
## Summary

- Add `inputHandles` + wired `ExpressionInput` (with `nodeId`/`handleId`) to 3 BOSL2 attachment nodes:
  - **AttachNode**: 1 handle (overlap)
  - **HalfOfNode**: 6 handles (vx, vy, vz, cpx, cpy, cpz)
  - **PartitionNode**: 4 handles (x, y, z, spread)
- Update `attachmentsCodegen.ts` to use `ctx.resolveValueInput()` so wired edges override local data
- Add 3 index-assertion tests to prevent handle-order regressions

## Design decisions

- All 3 nodes are transforms, so `in-0` = child geometry, parameter handles start at `in-1`
- TextInput-only nodes (diff, intersect, position, tag, recolor) unchanged — no ExpressionInputs to wire
- cutpath (TextInput on partition) stays unwired, matching shapes3d convention

## Test plan

- [x] `npm test` — 325 tests pass
- [ ] Visual check — attach/half_of/partition show left-side input handles
- [ ] Wire test — connect parameter node to input, verify codegen uses variable name

🤖 Generated with [Claude Code](https://claude.com/claude-code)